### PR TITLE
Add support for using vector tiles as a widget

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,6 +51,20 @@ class _MyHomePageState extends State<MyHomePage> {
                     InteractiveFlag.pinchMove |
                     InteractiveFlag.flingAnimation,
                 plugins: [VectorMapTilesPlugin()]),
+            // Can also be used as a native widget
+            // children: [
+            //   VectorTileLayerWidget(options: VectorTileLayerOptions(
+            //       theme: _mapTheme(context),
+            //       tileProvider: MemoryCacheVectorTileProvider(
+            //           delegate: NetworkVectorTileProvider(
+            //               urlTemplate: _urlTemplate(),
+            //               // this is the maximum zoom of the provider, not the
+            //               // maximum of the map. vector tiles are rendered
+            //               // to larger sizes to support higher zoom levels
+            //               maximumZoom: 14),
+            //           maxSizeBytes: 1024 * 1024 * 2)),
+            //   )
+            // ],
             layers: <LayerOptions>[
               // normally you would see TileLayerOptions which provides raster tiles
               // instead this vector tile layer replaces the standard tile layer

--- a/lib/src/vector_tile_widget.dart
+++ b/lib/src/vector_tile_widget.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_map/plugin_api.dart';
+import 'package:vector_map_tiles/src/grid/grid_layer.dart';
+import 'package:vector_map_tiles/src/options.dart';
+
+class VectorTileLayerWidget extends StatelessWidget {
+  final VectorTileLayerOptions options;
+
+  const VectorTileLayerWidget({Key? key, required this.options})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final mapState = MapState.maybeOf(context)!;
+    return VectorTileLayer(options, mapState, mapState.onMoved);
+  }
+}

--- a/lib/vector_map_tiles.dart
+++ b/lib/vector_map_tiles.dart
@@ -4,3 +4,4 @@ export 'src/plugin.dart';
 export 'src/options.dart';
 export 'src/tile_identity.dart';
 export 'src/vector_tile_provider.dart';
+export 'src/vector_tile_widget.dart';


### PR DESCRIPTION
Adds support for using the vector tiles layer as a widget in flutter_map children.