### PR TITLE
Change cache depending on theme

### DIFF
--- a/lib/src/cache/caches.dart
+++ b/lib/src/cache/caches.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:path_provider/path_provider.dart';
+import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 import '../grid/renderer_pipeline.dart';
 import 'memory_image_cache.dart';
 import 'storage_cache.dart';
@@ -27,9 +28,10 @@ class Caches {
       required int maxImagesInMemory,
       required int maxSizeInBytes}) {
     _cache = StorageCache(_storage, ttl, maxSizeInBytes);
-    vectorTileCache = VectorTileLoadingCache(_cache, provider);
-    imageTileCache = ImageTileLoadingCache(TileImageCache(_cache), pipeline);
-    memoryImageCache = MemoryImageCache(maxImagesInMemory);
+    var _cacheId = "${pipeline.theme.id}_${pipeline.theme.version}";
+    vectorTileCache = VectorTileLoadingCache(_cache, provider, _cacheId);
+    imageTileCache = ImageTileLoadingCache(TileImageCache(_cache, _cacheId), pipeline);
+    memoryImageCache = MemoryImageCache(maxImagesInMemory, _cacheId);
   }
 
   Future<void> applyConstraints() => _cache.applyConstraints();

--- a/lib/src/cache/memory_image_cache.dart
+++ b/lib/src/cache/memory_image_cache.dart
@@ -8,8 +8,9 @@ import 'cache_stats.dart';
 class MemoryImageCache with CacheStats {
   int _maxSize;
   final _cache = LinkedHashMap<String, Image>();
+  final _cacheId;
 
-  MemoryImageCache(this._maxSize);
+  MemoryImageCache(this._maxSize, this._cacheId);
 
   void putImage(TileIdentity id, {required double zoom, required Image image}) {
     final key = _toKey(id, zoom);
@@ -55,5 +56,5 @@ class MemoryImageCache with CacheStats {
   }
 
   String _toKey(TileIdentity id, double zoom) =>
-      '${id.z}.${id.x}.${id.y}.$zoom';
+      '${_cacheId}_${id.z}.${id.x}.${id.y}.$zoom';
 }

--- a/lib/src/cache/tile_image_cache.dart
+++ b/lib/src/cache/tile_image_cache.dart
@@ -6,8 +6,9 @@ import '../tile_identity.dart';
 
 class TileImageCache {
   final StorageCache _delegate;
+  final String _cacheId;
 
-  TileImageCache(this._delegate);
+  TileImageCache(this._delegate, this._cacheId);
 
   Future<Image?> retrieve(TileIdentity tile, String modifier) async {
     final key = _toKey(tile, modifier);
@@ -53,5 +54,5 @@ class TileImageCache {
   }
 
   String _toKey(TileIdentity id, String modifier) =>
-      '${id.z}_${id.x}_${id.y}_$modifier.png';
+      '${_cacheId}_${id.z}_${id.x}_${id.y}_$modifier.png';
 }

--- a/lib/src/cache/vector_tile_loading_cache.dart
+++ b/lib/src/cache/vector_tile_loading_cache.dart
@@ -9,8 +9,9 @@ import 'storage_cache.dart';
 class VectorTileLoadingCache {
   final StorageCache _delegate;
   final VectorTileProvider _provider;
+  final String _cacheId;
 
-  VectorTileLoadingCache(this._delegate, this._provider);
+  VectorTileLoadingCache(this._delegate, this._provider, this._cacheId);
 
   int get maximumZoom => _provider.maximumZoom;
 
@@ -31,5 +32,5 @@ class VectorTileLoadingCache {
     }
   }
 
-  String _toKey(TileIdentity id) => '${id.z}_${id.x}_${id.y}.pbf';
+  String _toKey(TileIdentity id) => '${_cacheId}_${id.z}_${id.x}_${id.y}.pbf';
 }


### PR DESCRIPTION
Update the caching mechanism so that the vector tile layer does not use old cache data when the tile provider changes. Currently this is implemented based on the theme but that should be fine since it can be used as a proxy for tile provider change notifications.