### PR TITLE
add error related to memory usage and zoom

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -48,7 +48,7 @@ class _MyHomePageState extends State<MyHomePage> {
             options: MapOptions(
                 center: LatLng(49.246292, -123.116226),
                 zoom: 10,
-                maxZoom: 15,
+                maxZoom: 16,
                 interactiveFlags: InteractiveFlag.drag |
                     InteractiveFlag.flingAnimation |
                     InteractiveFlag.pinchMove |

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -62,12 +62,22 @@ class VectorTileLayerOptions extends LayerOptions {
   /// This setting has no effect in debug mode.
   final int concurrency;
 
-  /// The default [concurrency] to use.
+  /// The default [concurrency]
   static const DEFAULT_CONCURRENCY = 2;
 
   /// The tile offset, defaults to [TileOffset.DEFAULT].
   /// See [TileOffset.mapbox]
   final TileOffset tileOffset;
+
+  /// The maximum zoom difference between map [MapOptions.maxZoom] and
+  /// [VectorTileProvider.maximumZoom]. This setting provides a guard
+  /// against inadvertent misconfiguration, since a difference between
+  /// tile size and map zoom can result in high memory usage.
+  /// More details at https://github.com/greensopinion/flutter-vector-map-tiles/issues/24
+  final int maximumZoomDifference;
+
+  /// the default [maximumZoomDifference]
+  static const DEFAULT_MAXIMUM_ZOOM_DIFFERENCE = 2;
 
   VectorTileLayerOptions(
       {required this.tileProviders,
@@ -81,8 +91,10 @@ class VectorTileLayerOptions extends LayerOptions {
       this.backgroundTheme,
       this.showTileDebugInfo = false,
       this.logCacheStats = false,
+      this.maximumZoomDifference = DEFAULT_MAXIMUM_ZOOM_DIFFERENCE,
       this.tileDelay = const Duration(milliseconds: 0)}) {
     assert(concurrency >= 0 && concurrency <= 100);
+    assert(maximumZoomDifference >= 0);
   }
 }
 

--- a/lib/src/plugin.dart
+++ b/lib/src/plugin.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/plugin_api.dart';
 
@@ -9,6 +11,7 @@ class VectorMapTilesPlugin extends MapPlugin {
   Widget createLayer(
       LayerOptions options, MapState mapState, Stream<Null> stream) {
     if (options is VectorTileLayerOptions) {
+      _checkZoomDifference(mapState, options);
       return VectorTileCompositeLayer(options, mapState, stream);
     }
     throw Exception('not supported: $options');
@@ -17,5 +20,23 @@ class VectorMapTilesPlugin extends MapPlugin {
   @override
   bool supportsLayer(LayerOptions options) {
     return options is VectorTileLayerOptions;
+  }
+
+  void _checkZoomDifference(MapState mapState, VectorTileLayerOptions options) {
+    final maxTileProviderZoom = options
+        .tileProviders.tileProviderBySource.values
+        .map((e) => e.maximumZoom)
+        .reduce(max);
+    final mapMaxZoom = mapState.options.maxZoom ?? maxTileProviderZoom;
+    final difference = (mapMaxZoom - maxTileProviderZoom).abs();
+    if (difference > options.maximumZoomDifference) {
+      throw 'Tile providers have a maximumZoom of $maxTileProviderZoom with map maximum zoom of $mapMaxZoom, ' +
+          'a difference of $difference which exceeds the maximum configured difference of ${options.maximumZoomDifference}. ' +
+          'A large difference in zoom levels can lead to application crashes due to lack of memory. ' +
+          'Consider setting MapOptions.maxZoom to ${maxTileProviderZoom + options.maximumZoomDifference} or increase ' +
+          'the maximumZoom of your TileProvider. If you are sure that you want to use a lot of memory, you can set ' +
+          'VectorTileLayerOptions.maximumZoomDifference to ${mapMaxZoom - maxTileProviderZoom} or higher ' +
+          'to avoid this error. See issue #24 for details.';
+    }
   }
 }


### PR DESCRIPTION
Add check for misconfigured maps so that
accidental misconfiguration can be caught
at development test time rather than
at run time.