### PR TITLE
updated flutter_map dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_map: '>= 1.0.0 <1.1.0'
+  flutter_map: ^1.1.0
     #path: ../flutter_map
   http: ^0.13.3
   latlong2: ^0.8.0


### PR DESCRIPTION
flutter_map just released 1.1.0 (https://github.com/fleaflet/flutter_map/blob/master/CHANGELOG.md), which is not allowed due to the constraints.

Is there a need to always restrict the next minor for flutter_map right now?