### PR TITLE
improve validation of themes

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -379,7 +379,7 @@ packages:
       name: vector_tile_renderer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.4"
+    version: "2.5.5"
   win32:
     dependency: transitive
     description:

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -4,6 +4,7 @@ import 'package:flutter_map/plugin_api.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
 import '../vector_map_tiles.dart';
+import './extensions.dart';
 
 /// a [FlutterMap] layer options, to be used with [VectorMapTilesPlugin].
 /// See the readme for details.
@@ -85,6 +86,18 @@ class VectorTileLayerOptions extends LayerOptions {
       this.logCacheStats = false,
       this.tileDelay = const Duration(milliseconds: 0)}) {
     assert(concurrency >= 0 && concurrency <= 100);
+    final providers = theme.tileSources
+        .map((source) => tileProviders.tileProviderBySource[source])
+        .whereType<VectorTileProvider>();
+    assert(
+        providers.isNotEmpty,
+        '''
+tileProviders must provide at least one provider that matches the given theme. 
+Usually this is an indication that TileProviders in the code doesn't match the sources
+required by the theme. 
+The theme uses the following sources: ${theme.tileSources.toList().sorted().join(', ')}.
+'''
+            .trim());
   }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -535,7 +535,7 @@ packages:
       name: vector_tile_renderer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.4"
+    version: "2.5.5"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   http: ^0.13.3
   latlong2: ^0.8.0
   path_provider: ^2.0.2
-  vector_tile_renderer: #^2.5.5
+  vector_tile_renderer: ^2.5.5
     #path: ../vector_tile_renderer
   async: ^2.8.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   http: ^0.13.3
   latlong2: ^0.8.0
   path_provider: ^2.0.2
-  vector_tile_renderer: ^2.5.4
+  vector_tile_renderer: #^2.5.5
     #path: ../vector_tile_renderer
   async: ^2.8.2
 


### PR DESCRIPTION
Check that at least one tile provider
matches a theme. This helps to guard
against code that does not match the
theme, which is a common misconfiguration.