### PR TITLE
display lower zoom tiles from cache when tiles at the current zoom are not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ build/
 !**/ios/**/default.perspectivev3
 
 coverage/
+example/lib/local_*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+## 2.4.0
+
+* improve usage on a slow internet connection by displaying lower zoom tiles from the cache while loading tiles
+* reduce chances of high memory usage
+
 ## 2.3.0
 
 * support flutter_map 2.1
+
 ## 2.2.2
 
 * provide support for dashed paths with `line-dasharray` theme style

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -379,7 +379,7 @@ packages:
       name: vector_tile_renderer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.9"
+    version: "2.6.2"
   win32:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -379,7 +379,7 @@ packages:
       name: vector_tile_renderer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.8"
+    version: "2.5.9"
   win32:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -358,7 +358,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/cache/caches.dart
+++ b/lib/src/cache/caches.dart
@@ -19,6 +19,7 @@ class Caches {
   late final StorageCache _cache;
   late final VectorTileLoadingCache vectorTileCache;
   late final MemoryCache memoryVectorTileCache;
+  late final MemoryTileDataCache memoryTileDataCache;
   late final TextCache textCache;
   late final List<String> providerSources;
 
@@ -28,13 +29,16 @@ class Caches {
       required Theme theme,
       required Duration ttl,
       required int memoryTileCacheMaxSize,
+      required int memoryTileDataCacheMaxSize,
       required int maxSizeInBytes,
       required int maxTextCacheSize}) {
     providerSources = providers.tileProviderBySource.keys.toList();
     _cache = StorageCache(_storage, ttl, maxSizeInBytes);
     memoryVectorTileCache = MemoryCache(maxSizeBytes: memoryTileCacheMaxSize);
-    vectorTileCache = VectorTileLoadingCache(
-        _cache, memoryVectorTileCache, providers, executor, theme);
+    memoryTileDataCache =
+        MemoryTileDataCache(maxSize: memoryTileDataCacheMaxSize);
+    vectorTileCache = VectorTileLoadingCache(_cache, memoryVectorTileCache,
+        memoryTileDataCache, providers, executor, theme);
     textCache = TextCache(maxSize: maxTextCacheSize);
   }
 
@@ -54,6 +58,8 @@ class Caches {
         .add('Storage cache hit ratio:           ${_cache.hitRatio.asPct()}%');
     cacheStats.add(
         'Vector tile cache hit ratio:       ${memoryVectorTileCache.hitRatio.asPct()}% size: ${memoryVectorTileCache.size}');
+    cacheStats.add(
+        'Tile data cache hit ratio:         ${memoryTileDataCache.hitRatio.asPct()}% size: ${memoryTileDataCache.size}');
     cacheStats.add(
         'Text cache hit ratio:              ${textCache.hitRatio.asPct()}% size: ${textCache.size}');
     return cacheStats.join('\n');

--- a/lib/src/cache/memory_cache.dart
+++ b/lib/src/cache/memory_cache.dart
@@ -1,5 +1,7 @@
 import 'dart:typed_data';
 
+import 'package:vector_tile_renderer/vector_tile_renderer.dart';
+
 import 'cache.dart';
 
 class MemoryCache extends Cache<String, Uint8List> {
@@ -10,4 +12,9 @@ class MemoryCache extends Cache<String, Uint8List> {
 class _Sizer extends Sizer<Uint8List> {
   @override
   int size(Uint8List value) => value.lengthInBytes;
+}
+
+class MemoryTileDataCache extends Cache<String, TileData> {
+  MemoryTileDataCache({required int maxSize})
+      : super(maxSize: maxSize, sizer: Sizer<TileData>(), copier: Copier());
 }

--- a/lib/src/cache/vector_tile_loading_cache.dart
+++ b/lib/src/cache/vector_tile_loading_cache.dart
@@ -19,15 +19,15 @@ class VectorTileLoadingCache {
   final Executor _executor;
   bool _ready = false;
   final _readyCompleter = Completer<bool>();
+  late final int maximumZoom;
 
   VectorTileLoadingCache(this._delegate, this._memoryCache, this._providers,
       this._executor, this._theme) {
+    maximumZoom = _providers.tileProviderBySource.values
+        .map((e) => e.maximumZoom)
+        .reduce(min);
     _initialize();
   }
-
-  int get maximumZoom => _providers.tileProviderBySource.values
-      .map((e) => e.maximumZoom)
-      .reduce(min);
 
   Future<TileData> retrieve(String source, TileIdentity tile,
       {required CancellationCallback cancelled}) async {

--- a/lib/src/grid/grid_layer.dart
+++ b/lib/src/grid/grid_layer.dart
@@ -105,7 +105,8 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
               symbolTheme: symbolTheme,
               showTileDebugInfo: options.showTileDebugInfo,
               paintBackground: backgroundTheme == null,
-              substituteTilesWhileLoading: true,
+              maxSubstitutionDifference:
+                  options.maximumTileSubstitutionDifference,
               paintNoDataTiles: false,
               tileOffset: widget.options.tileOffset,
               mapZoom: () =>
@@ -121,7 +122,7 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
               caches: _caches,
               showTileDebugInfo: options.showTileDebugInfo,
               paintBackground: true,
-              substituteTilesWhileLoading: false,
+              maxSubstitutionDifference: 0,
               paintNoDataTiles: true,
               tileOffset: widget.options.tileOffset,
               mapZoom: _backgroundZoom),
@@ -172,7 +173,7 @@ class _LayerOptions {
   final Theme? symbolTheme;
   final bool showTileDebugInfo;
   final bool paintBackground;
-  final bool substituteTilesWhileLoading;
+  final int maxSubstitutionDifference;
   final bool paintNoDataTiles;
   final TileOffset tileOffset;
   final double Function() mapZoom;
@@ -183,7 +184,7 @@ class _LayerOptions {
       required this.showTileDebugInfo,
       required this.paintBackground,
       required this.paintNoDataTiles,
-      required this.substituteTilesWhileLoading,
+      required this.maxSubstitutionDifference,
       required this.tileOffset,
       required this.mapZoom});
 }
@@ -254,7 +255,7 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
         widget.options.symbolTheme,
         widget.tileProvider,
         widget.options.caches.textCache,
-        widget.options.substituteTilesWhileLoading,
+        widget.options.maxSubstitutionDifference,
         widget.options.paintBackground,
         widget.options.showTileDebugInfo);
     _tileWidgets.addListener(() {

--- a/lib/src/grid/grid_layer.dart
+++ b/lib/src/grid/grid_layer.dart
@@ -3,8 +3,6 @@ import 'dart:math';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/plugin_api.dart';
-import '../stream/tile_processor.dart';
-import '../stream/tileset_ui_preprocessor.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
 import '../cache/caches.dart';
@@ -12,14 +10,16 @@ import '../executor/executor.dart';
 import '../options.dart';
 import '../stream/caches_tile_provider.dart';
 import '../stream/delay_provider.dart';
+import '../stream/tile_processor.dart';
 import '../stream/tileset_executor_preprocessor.dart';
+import '../stream/tileset_ui_preprocessor.dart';
 import '../stream/translating_tile_provider.dart';
 import '../tile_identity.dart';
 import '../tile_viewport.dart';
 import 'constants.dart';
 import 'debounce.dart';
-import 'tile/disposable_state.dart';
 import 'grid_tile_positioner.dart';
+import 'tile/disposable_state.dart';
 import 'tile_widgets.dart';
 
 class VectorTileCompositeLayer extends StatefulWidget {
@@ -269,7 +269,7 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
     final tiles = _tileWidgets.all.entries
         .where((entry) =>
             widget.options.paintNoDataTiles || entry.value.model.hasData)
-        .toList()
+        .toList(growable: false)
       ..sort(_orderTileWidgets);
     if (tiles.isEmpty) {
       return Container();

--- a/lib/src/grid/grid_layer.dart
+++ b/lib/src/grid/grid_layer.dart
@@ -109,8 +109,8 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
                   options.maximumTileSubstitutionDifference,
               paintNoDataTiles: false,
               tileOffset: widget.options.tileOffset,
-              mapZoom: () =>
-                  widget.mapState.zoom + widget.options.tileOffset.zoomOffset),
+              tileZoomSubstitutionOffset: 0,
+              mapZoom: _zoom),
           widget.mapState,
           widget.stream,
           _tileSupplier)
@@ -125,7 +125,8 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
               maxSubstitutionDifference: 0,
               paintNoDataTiles: true,
               tileOffset: widget.options.tileOffset,
-              mapZoom: _backgroundZoom),
+              tileZoomSubstitutionOffset: 4,
+              mapZoom: _zoom),
           widget.mapState,
           widget.stream,
           _tileSupplier);
@@ -141,6 +142,7 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
         theme: widget.options.theme,
         ttl: widget.options.fileCacheTtl,
         memoryTileCacheMaxSize: widget.options.memoryTileCacheMaxSize,
+        memoryTileDataCacheMaxSize: widget.options.memoryTileDataCacheMaxSize,
         maxSizeInBytes: widget.options.fileCacheMaximumSizeInBytes,
         maxTextCacheSize: widget.options.textCacheMaxSize);
     _tileSupplier = TranslatingTileProvider(DelayProvider(
@@ -160,12 +162,10 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
     print('Cache stats:\n${_caches.stats()}');
   }
 
-  double _backgroundZoom() {
-    return max(
-        1,
-        (widget.mapState.zoom - 1 + widget.options.tileOffset.zoomOffset)
-            .floorToDouble());
-  }
+  double _zoom() => max(
+      1,
+      (widget.mapState.zoom + widget.options.tileOffset.zoomOffset)
+          .floorToDouble());
 }
 
 class _LayerOptions {
@@ -176,6 +176,7 @@ class _LayerOptions {
   final int maxSubstitutionDifference;
   final bool paintNoDataTiles;
   final TileOffset tileOffset;
+  final int tileZoomSubstitutionOffset;
   final double Function() mapZoom;
   final Caches caches;
   _LayerOptions(this.theme,
@@ -186,6 +187,7 @@ class _LayerOptions {
       required this.paintNoDataTiles,
       required this.maxSubstitutionDifference,
       required this.tileOffset,
+      required this.tileZoomSubstitutionOffset,
       required this.mapZoom});
 }
 
@@ -256,6 +258,7 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
         widget.tileProvider,
         widget.options.caches.textCache,
         widget.options.maxSubstitutionDifference,
+        widget.options.tileZoomSubstitutionOffset,
         widget.options.paintBackground,
         widget.options.showTileDebugInfo);
     _tileWidgets.addListener(() {

--- a/lib/src/grid/grid_vector_tile.dart
+++ b/lib/src/grid/grid_vector_tile.dart
@@ -6,8 +6,10 @@ import 'tile/delay_painter.dart';
 import 'tile/disposable_state.dart';
 import 'tile/symbols.dart';
 import 'tile/tile_layer_debug.dart';
+import 'tile/tile_layer_painter.dart';
 import 'tile/tile_options.dart';
 import 'tile/tile_painter.dart';
+import 'tile_layer_model.dart';
 import 'tile_model.dart';
 
 class GridVectorTile extends material.StatefulWidget {
@@ -37,7 +39,7 @@ class _GridVectorTileState extends DisposableState<GridVectorTile> {
     final model = widget.model;
     final textCache = widget.textCache;
     final symbolTheme = model.symbolTheme;
-    options = VectorTileOptions(model, model.theme,
+    options = VectorTileOptions(model, model.layers.first.theme,
         textCache: textCache,
         paintBackground: model.paintBackground,
         symbolsDelayPainterModel: null);
@@ -71,7 +73,12 @@ class _GridVectorTileState extends DisposableState<GridVectorTile> {
         child: CustomPaint(painter: _painter));
 
     final children = <Widget>[tile];
-
+    if (widget.model.layers.length > 1) {
+      for (final tileLayerModel in widget.model.layers.sublist(1)) {
+        children.add(_GridVectorTileLayer(
+            model: tileLayerModel, key: Key('tileLayer${tileLayerModel.id}')));
+      }
+    }
     final symbolPainter = _symbolPainter;
     if (symbolPainter != null) {
       children.add(DelayPainter(
@@ -87,5 +94,37 @@ class _GridVectorTileState extends DisposableState<GridVectorTile> {
       return Stack(fit: StackFit.expand, children: children);
     }
     return tile;
+  }
+}
+
+class _GridVectorTileLayer extends material.StatefulWidget {
+  final TileLayerModel model;
+
+  const _GridVectorTileLayer({material.Key? key, required this.model})
+      : super(key: key);
+
+  @override
+  material.State<material.StatefulWidget> createState() {
+    return _GridVectorTileLayerState();
+  }
+}
+
+class _GridVectorTileLayerState extends State<_GridVectorTileLayer> {
+  late final TileLayerPainter _painter;
+
+  @override
+  void initState() {
+    super.initState();
+    _painter = TileLayerPainter(widget.model);
+    widget.model.addListener(() {
+      setState(() {});
+    });
+  }
+
+  @override
+  material.Widget build(material.BuildContext context) {
+    return RepaintBoundary(
+        key: Key('tileLayerBoundary${widget.model.id}'),
+        child: CustomPaint(painter: _painter));
   }
 }

--- a/lib/src/grid/tile/tile_layer_debug.dart
+++ b/lib/src/grid/tile/tile_layer_debug.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'tile_options.dart';
 
 import '../grid_tile_positioner.dart';
+import 'tile_options.dart';
 
 class TileDebugLayer extends StatelessWidget {
   final VectorTileOptions options;
@@ -30,7 +30,13 @@ class _TileDebugPainter extends CustomPainter {
     final paint = Paint()
       ..strokeWidth = 2.0
       ..style = PaintingStyle.stroke
-      ..color = const Color.fromARGB(0xff, 0, 0xff, 0);
+      ..color = Colors.green;
+    if (translation.zoomDifference != 0) {
+      final maxZoom = options.model.tileProvider.maximumZoom;
+      if (translation.translated.z != maxZoom) {
+        paint.color = Colors.deepOrange;
+      }
+    }
     canvas.drawLine(Offset.zero, Offset(0, size.height), paint);
     canvas.drawLine(Offset.zero, Offset(size.width, 0), paint);
     final textStyle = TextStyle(
@@ -41,7 +47,7 @@ class _TileDebugPainter extends CustomPainter {
         text: TextSpan(
             style: textStyle,
             text:
-                '${options.model.tile}\nzoom=${zoom.zoom.toStringAsFixed(3)} zoomDetail=${zoom.zoomDetail.toStringAsFixed(3)}\nscale=$roundedScale\nsize=${size.width}\npaintCount=${options.paintCount}'),
+                '${options.model.tile}\ntranslated=${translation.zoomDifference} from ${translation.translated.z}\nzoom=${zoom.zoom.toStringAsFixed(3)} zoomDetail=${zoom.zoomDetail.toStringAsFixed(3)}\nscale=$roundedScale\nsize=${size.width}\npaintCount=${options.paintCount}'),
         textAlign: TextAlign.start,
         textDirection: TextDirection.ltr)
       ..layout();

--- a/lib/src/grid/tile/tile_layer_debug.dart
+++ b/lib/src/grid/tile/tile_layer_debug.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:vector_map_tiles/src/grid/tile/tile_options.dart';
+import 'tile_options.dart';
 
 import '../grid_tile_positioner.dart';
 
@@ -25,8 +25,8 @@ class _TileDebugPainter extends CustomPainter {
     if (translation == null) {
       return;
     }
-    final tileSizer = GridTileSizer(translation,
-        options.model.zoomScaleFunction(options.model.tile.z), size);
+    final zoom = options.model.zoomProvider.provide();
+    final tileSizer = GridTileSizer(translation, zoom.zoomScale, size);
     final paint = Paint()
       ..strokeWidth = 2.0
       ..style = PaintingStyle.stroke
@@ -37,13 +37,11 @@ class _TileDebugPainter extends CustomPainter {
         foreground: Paint()..color = const Color.fromARGB(0xff, 0, 0, 0),
         fontSize: 15);
     final roundedScale = tileSizer.effectiveScale.toStringAsFixed(3);
-    final zoom = options.model.zoomFunction().toStringAsFixed(3);
-    final zoomDetail = options.model.zoomDetailFunction().toStringAsFixed(3);
     final text = TextPainter(
         text: TextSpan(
             style: textStyle,
             text:
-                '${options.model.tile}\nzoom=$zoom zoomDetail=$zoomDetail\nscale=$roundedScale\npaintCount=${options.paintCount}  '),
+                '${options.model.tile}\nzoom=${zoom.zoom.toStringAsFixed(3)} zoomDetail=${zoom.zoomDetail.toStringAsFixed(3)}\nscale=$roundedScale\npaintCount=${options.paintCount}'),
         textAlign: TextAlign.start,
         textDirection: TextDirection.ltr)
       ..layout();

--- a/lib/src/grid/tile/tile_layer_debug.dart
+++ b/lib/src/grid/tile/tile_layer_debug.dart
@@ -41,7 +41,7 @@ class _TileDebugPainter extends CustomPainter {
         text: TextSpan(
             style: textStyle,
             text:
-                '${options.model.tile}\nzoom=${zoom.zoom.toStringAsFixed(3)} zoomDetail=${zoom.zoomDetail.toStringAsFixed(3)}\nscale=$roundedScale\npaintCount=${options.paintCount}'),
+                '${options.model.tile}\nzoom=${zoom.zoom.toStringAsFixed(3)} zoomDetail=${zoom.zoomDetail.toStringAsFixed(3)}\nscale=$roundedScale\nsize=${size.width}\npaintCount=${options.paintCount}'),
         textAlign: TextAlign.start,
         textDirection: TextDirection.ltr)
       ..layout();

--- a/lib/src/grid/tile/tile_layer_painter.dart
+++ b/lib/src/grid/tile/tile_layer_painter.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/widgets.dart';
-import '../tile_layer_model.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
 import '../grid_tile_positioner.dart';
+import '../tile_layer_model.dart';
 
 class TileLayerPainter extends CustomPainter {
   final TileLayerModel model;

--- a/lib/src/grid/tile/tile_layer_painter.dart
+++ b/lib/src/grid/tile/tile_layer_painter.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/widgets.dart';
+import '../tile_layer_model.dart';
+import 'package:vector_tile_renderer/vector_tile_renderer.dart';
+
+import '../grid_tile_positioner.dart';
+
+class TileLayerPainter extends CustomPainter {
+  final TileLayerModel model;
+
+  TileLayerPainter(this.model) : super(repaint: model);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final zoom = model.updateRendering();
+    final tileset = model.tileset;
+    final translation = model.translation;
+    if (tileset == null || translation == null || !model.visible) {
+      return;
+    }
+
+    canvas.save();
+    canvas.clipRect(Offset.zero & size);
+    final tileSizer = GridTileSizer(translation, zoom.zoomScale, size);
+    tileSizer.apply(canvas);
+
+    final tileClip = tileSizer.tileClip(size, tileSizer.effectiveScale);
+    Renderer(theme: model.theme).render(canvas, model.tileset!,
+        clip: tileClip,
+        zoomScaleFactor: tileSizer.effectiveScale,
+        zoom: zoom.zoom);
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(covariant TileLayerPainter oldDelegate) =>
+      model.hasChanged();
+}

--- a/lib/src/grid/tile/tile_painter.dart
+++ b/lib/src/grid/tile/tile_painter.dart
@@ -28,7 +28,7 @@ class VectorTilePainter extends CustomPainter {
     if (model.disposed) {
       return;
     }
-    model.updateRendering();
+    final zoom = model.updateRendering();
     if (model.tileset == null) {
       if (options.paintBackground) {
         _paintBackground(canvas, size);
@@ -40,8 +40,7 @@ class VectorTilePainter extends CustomPainter {
       return;
     }
     ++options.paintCount;
-    final tileSizer =
-        GridTileSizer(translation, model.zoomScaleFunction(model.tile.z), size);
+    final tileSizer = GridTileSizer(translation, zoom.zoomScale, size);
     canvas.save();
     canvas.clipRect(Offset.zero & size);
     tileSizer.apply(canvas);
@@ -51,7 +50,7 @@ class VectorTilePainter extends CustomPainter {
         .render(canvas, model.tileset!,
             clip: tileClip,
             zoomScaleFactor: tileSizer.effectiveScale,
-            zoom: model.lastRenderedZoomDetail);
+            zoom: zoom.zoomDetail);
     _lastPainted = _PaintMode.vector;
     _lastPaintedId = translation.translated;
 
@@ -63,7 +62,7 @@ class VectorTilePainter extends CustomPainter {
   void _paintBackground(Canvas canvas, Size size) {
     final model = options.model;
     final tileSizer = GridTileSizer(
-        model.defaultTranslation, model.zoomScaleFunction(model.tile.z), size);
+        model.defaultTranslation, model.lastRenderedZoom.zoomScale, size);
     canvas.save();
     canvas.clipRect(Offset.zero & size);
     tileSizer.apply(canvas);
@@ -71,7 +70,7 @@ class VectorTilePainter extends CustomPainter {
     Renderer(theme: options.theme).render(canvas, Tileset({}),
         clip: tileClip,
         zoomScaleFactor: tileSizer.effectiveScale,
-        zoom: model.lastRenderedZoom);
+        zoom: model.lastRenderedZoom.zoom);
     _lastPainted = _PaintMode.background;
     _lastPaintedId = null;
     canvas.restore();

--- a/lib/src/grid/tile/tile_painter.dart
+++ b/lib/src/grid/tile/tile_painter.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
-import '../../cache/text_cache.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
+import '../../cache/text_cache.dart';
 import '../../tile_identity.dart';
 import '../grid_tile_positioner.dart';
 import 'symbols.dart';

--- a/lib/src/grid/tile_layer_composer.dart
+++ b/lib/src/grid/tile_layer_composer.dart
@@ -1,7 +1,7 @@
-import 'tile_model.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
 import 'tile_layer_model.dart';
+import 'tile_model.dart';
 
 class TileLayerComposer {
   List<TileLayerModel> compose(VectorTileModel vectorTileModel, Theme theme) {

--- a/lib/src/grid/tile_layer_composer.dart
+++ b/lib/src/grid/tile_layer_composer.dart
@@ -1,0 +1,67 @@
+import 'tile_model.dart';
+import 'package:vector_tile_renderer/vector_tile_renderer.dart';
+
+import 'tile_layer_model.dart';
+
+class TileLayerComposer {
+  List<TileLayerModel> compose(VectorTileModel vectorTileModel, Theme theme) {
+    final layersByGroupId = <String, _Layer>{};
+    var groupSeed = 0;
+    String? currentGroupId;
+    String currentGroupKey = 'none-$groupSeed';
+    var currentGroup = _Layer(Duration.zero, Duration.zero);
+    layersByGroupId[currentGroupKey] = currentGroup;
+    for (final layer in theme.layers) {
+      final groupId = layer.metadata[LayerMetadata.layerGroup];
+      final newGroup = (groupId != currentGroupId);
+      if (newGroup) {
+        currentGroupId = groupId;
+        currentGroupKey = groupId ?? 'none-${++groupSeed}';
+        while (layersByGroupId.containsKey(currentGroupKey)) {
+          ++groupSeed;
+          currentGroupKey =
+              (groupId == null) ? 'none-$groupSeed' : '$groupId-$groupSeed';
+        }
+        final layerDelay = layer.metadata[LayerMetadata.layerDelay];
+        final layerInitialDelay =
+            layer.metadata[LayerMetadata.layerInitialDelay] ?? layerDelay;
+        currentGroup = _Layer(
+            layerInitialDelay is num
+                ? Duration(milliseconds: layerInitialDelay.toInt())
+                : Duration.zero,
+            layerDelay is num
+                ? Duration(milliseconds: layerDelay.toInt())
+                : Duration.zero);
+        layersByGroupId[currentGroupKey] = currentGroup;
+      }
+      currentGroup.themeLayers.add(layer);
+    }
+    return layersByGroupId.entries
+        .map((e) => TileLayerModel(
+            tileModel: vectorTileModel,
+            delay: e.value.delay,
+            initialDelay: e.value.initialDelay,
+            theme: Theme(
+                id: '${theme.id}_${e.key}',
+                layers: e.value.themeLayers,
+                version: theme.version),
+            id: '${theme.id}_${e.key}',
+            tileset: null))
+        .toList(growable: false);
+  }
+}
+
+class LayerMetadata {
+  static const prefix = 'vector_map_tiles';
+  static const layerGroup = '$prefix:layer-group';
+  static const layerInitialDelay = '$prefix:layer-initial-delay';
+  static const layerDelay = '$prefix:layer-delay';
+}
+
+class _Layer {
+  final Duration delay;
+  final Duration initialDelay;
+  final themeLayers = <ThemeLayer>[];
+
+  _Layer(this.initialDelay, this.delay);
+}

--- a/lib/src/grid/tile_layer_model.dart
+++ b/lib/src/grid/tile_layer_model.dart
@@ -20,7 +20,7 @@ class TileLayerModel extends ChangeNotifier {
   late final ScheduledDebounce debounce;
   TileZoom lastRenderedZoom = TileZoom.undefined();
   var lastRenderedVisible = true;
-  TileIdentity? lastRenderedTile = null;
+  TileIdentity? lastRenderedTile;
   var _renderedOnce = false;
 
   TileLayerModel(

--- a/lib/src/grid/tile_layer_model.dart
+++ b/lib/src/grid/tile_layer_model.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import '../../vector_map_tiles.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
 import 'debounce.dart';
@@ -19,6 +20,7 @@ class TileLayerModel extends ChangeNotifier {
   late final ScheduledDebounce debounce;
   TileZoom lastRenderedZoom = TileZoom.undefined();
   var lastRenderedVisible = true;
+  TileIdentity? lastRenderedTile = null;
   var _renderedOnce = false;
 
   TileLayerModel(
@@ -56,6 +58,7 @@ class TileLayerModel extends ChangeNotifier {
     final previousRenderedZoom = lastRenderedZoom;
     lastRenderedZoom = tileModel.zoomProvider.provide();
     lastRenderedVisible = visible;
+    lastRenderedTile = tileModel.translation?.translated;
     if (previousRenderedZoom != lastRenderedZoom &&
         nextDelay().inMilliseconds > 0) {
       visible = false;
@@ -76,5 +79,6 @@ class TileLayerModel extends ChangeNotifier {
 
   bool hasChanged() =>
       visible != lastRenderedVisible ||
-      lastRenderedZoom != tileModel.zoomProvider.provide();
+      lastRenderedZoom != tileModel.zoomProvider.provide() ||
+      lastRenderedTile != tileModel.translation?.translated;
 }

--- a/lib/src/grid/tile_layer_model.dart
+++ b/lib/src/grid/tile_layer_model.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/widgets.dart';
+import 'package:vector_tile_renderer/vector_tile_renderer.dart';
+
+import 'debounce.dart';
+import 'slippy_map_translator.dart';
+import 'tile_model.dart';
+import 'tile_zoom.dart';
+
+class TileLayerModel extends ChangeNotifier {
+  final String id;
+  final Theme theme;
+  final Duration delay;
+  final Duration initialDelay;
+  Tileset? tileset;
+  TileTranslation? translation;
+  final VectorTileModel tileModel;
+  var _disposed = false;
+  var visible = true;
+  late final ScheduledDebounce debounce;
+  TileZoom lastRenderedZoom = TileZoom.undefined();
+  var lastRenderedVisible = true;
+  var _renderedOnce = false;
+
+  TileLayerModel(
+      {required this.theme,
+      required this.id,
+      required this.delay,
+      required this.initialDelay,
+      required this.tileset,
+      required this.tileModel}) {
+    debounce = ScheduledDebounce(_makeVisible,
+        delay: delay,
+        jitter: Duration(milliseconds: delay.inMilliseconds ~/ 2),
+        maxAge: Duration(milliseconds: delay.inMilliseconds * 20));
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
+
+  @override
+  void notifyListeners() {
+    if (!_disposed) {
+      super.notifyListeners();
+    }
+  }
+
+  void _makeVisible() {
+    visible = true;
+    notifyListeners();
+  }
+
+  TileZoom updateRendering() {
+    final previousRenderedZoom = lastRenderedZoom;
+    lastRenderedZoom = tileModel.zoomProvider.provide();
+    lastRenderedVisible = visible;
+    if (previousRenderedZoom != lastRenderedZoom &&
+        nextDelay().inMilliseconds > 0) {
+      visible = false;
+      debounce.update();
+    }
+    if (visible) {
+      _renderedOnce = true;
+    }
+    return lastRenderedZoom;
+  }
+
+  Duration nextDelay() {
+    if (!_renderedOnce && initialDelay.inMilliseconds > 0) {
+      return initialDelay;
+    }
+    return delay;
+  }
+
+  bool hasChanged() =>
+      visible != lastRenderedVisible ||
+      lastRenderedZoom != tileModel.zoomProvider.provide();
+}

--- a/lib/src/grid/tile_model.dart
+++ b/lib/src/grid/tile_model.dart
@@ -1,7 +1,10 @@
 import 'dart:developer';
+import 'dart:io';
+import 'dart:math';
 import 'dart:ui' as ui;
 
 import 'package:flutter/widgets.dart';
+import '../stream/translated_tile_request.dart';
 import 'tile_zoom.dart';
 import 'tile_layer_composer.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
@@ -15,6 +18,7 @@ import 'tile_layer_model.dart';
 
 class VectorTileModel extends ChangeNotifier {
   bool _disposed = false;
+
   bool get disposed => _disposed;
 
   final TileIdentity tile;
@@ -25,6 +29,7 @@ class VectorTileModel extends ChangeNotifier {
   final bool showTileDebugInfo;
   late final TileZoomProvider zoomProvider;
   TileZoom lastRenderedZoom = TileZoom.undefined();
+  TileIdentity? lastRenderedTile;
 
   late final TileTranslation defaultTranslation;
   TileTranslation? translation;
@@ -62,14 +67,8 @@ class VectorTileModel extends ChangeNotifier {
     }
   }
 
-  void startLoading() async {
-    final zoom = zoomProvider.provide();
-    final request = TileRequest(
-        tileId: tile.normalize(),
-        zoom: zoom.zoom,
-        zoomDetail: zoom.zoomDetail,
-        cancelled: () => _disposed);
-    tileProvider.provide(request).swallowCancellation().maybeThen(_receiveTile);
+  void startLoading() {
+    _VectorTileModelLoader(this).startLoading();
   }
 
   void _receiveTile(TileResponse received) {
@@ -87,6 +86,7 @@ class VectorTileModel extends ChangeNotifier {
 
   TileZoom updateRendering() {
     lastRenderedZoom = zoomProvider.provide();
+    lastRenderedTile = translation?.translated;
     return lastRenderedZoom;
   }
 
@@ -96,7 +96,9 @@ class VectorTileModel extends ChangeNotifier {
     }
   }
 
-  bool hasChanged() => lastRenderedZoom != zoomProvider.provide();
+  bool hasChanged() =>
+      lastRenderedZoom != zoomProvider.provide() ||
+      lastRenderedTile != translation?.translated;
 
   @override
   void notifyListeners() {
@@ -152,5 +154,57 @@ class VectorTileSymbolState extends ChangeNotifier {
     if (!_disposed) {
       super.notifyListeners();
     }
+  }
+}
+
+class _VectorTileModelLoader {
+  final VectorTileModel model;
+
+  _VectorTileModelLoader(this.model);
+
+  void startLoading() async {
+    final originalTile = model.tile.normalize();
+    final maxZoom = model.tileProvider.maximumZoom;
+    var originalLoaded = false;
+    final int startZoom = min(originalTile.z, maxZoom);
+    for (int z = startZoom; z >= max(startZoom - 10, 1); --z) {
+      final request = createTranslatedRequest(_newRequest(), maximumZoom: z);
+      final localTile = await model.tileProvider
+          .provideLocalCopy(request)
+          .swallowCancellation();
+      if (model.disposed) {
+        break;
+      }
+      if (localTile != null && localTile.tileset != null) {
+        model._receiveTile(localTile);
+        originalLoaded = z == originalTile.z;
+        if (model.hasData) {
+          break;
+        }
+      }
+    }
+    if (!originalLoaded && !model.disposed) {
+      try {
+        final response = await model.tileProvider.provide(_newRequest());
+        model._receiveTile(response);
+      } catch (e) {
+        if (e is SocketException) {
+          // nothing to do
+        } else if (e is CancellationException) {
+          // nothing to do
+        } else {
+          rethrow;
+        }
+      }
+    }
+  }
+
+  TileRequest _newRequest() {
+    final zoom = model.zoomProvider.provide();
+    return TileRequest(
+        tileId: model.tile.normalize(),
+        zoom: zoom.zoom,
+        zoomDetail: zoom.zoomDetail,
+        cancelled: () => model.disposed);
   }
 }

--- a/lib/src/grid/tile_widgets.dart
+++ b/lib/src/grid/tile_widgets.dart
@@ -8,6 +8,7 @@ import '../tile_viewport.dart';
 import 'grid_vector_tile.dart';
 import 'slippy_map_translator.dart';
 import 'tile_model.dart';
+import 'tile_zoom.dart';
 
 class TileWidgets extends ChangeNotifier {
   bool _disposed = false;
@@ -178,10 +179,8 @@ class TileWidgets extends ChangeNotifier {
   Set<TileIdentity> _reduce(List<TileIdentity> tiles) {
     final translator = SlippyMapTranslator(_tileProvider.maximumZoom);
     final reduced = <TileIdentity>{};
-    const overzoomStep = 1;
     for (final tile in tiles) {
-      final zoomStep =
-          tile.z > _tileProvider.maximumZoom ? tile.z - overzoomStep : tile.z;
+      final zoomStep = tile.z > _tileProvider.maximumZoom ? tile.z : tile.z;
       final translation =
           translator.specificZoomTranslation(tile, zoom: zoomStep);
       reduced.add(translation.translated);

--- a/lib/src/grid/tile_widgets.dart
+++ b/lib/src/grid/tile_widgets.dart
@@ -25,7 +25,7 @@ class TileWidgets extends ChangeNotifier {
   final TextCache _textCache;
   final bool paintBackground;
   final bool showTileDebugInfo;
-  final bool substituteTilesWhileLoading;
+  final int maxSubstitutionDifference;
 
   TileWidgets(
       this._zoomScaleFunction,
@@ -35,7 +35,7 @@ class TileWidgets extends ChangeNotifier {
       this._symbolTheme,
       this._tileProvider,
       this._textCache,
-      this.substituteTilesWhileLoading,
+      this.maxSubstitutionDifference,
       this.paintBackground,
       this.showTileDebugInfo);
 
@@ -55,11 +55,11 @@ class TileWidgets extends ChangeNotifier {
     _idToModel = {};
 
     Set<TileIdentity> effectiveTiles = _reduce(tiles);
-    if (substituteTilesWhileLoading && effectiveTiles.isNotEmpty) {
+    if (maxSubstitutionDifference > 0 && effectiveTiles.isNotEmpty) {
       final z = effectiveTiles.first.z;
       final obsoleteSubstitutions = _substitutionModels
           .where((m) =>
-              m.disposed || (m.tile.z - z).abs() > _maxSubstitutionDifference)
+              m.disposed || (m.tile.z - z).abs() > maxSubstitutionDifference)
           .toList();
       for (final obsolete in obsoleteSubstitutions) {
         _removeAndDispose(obsolete);
@@ -91,7 +91,7 @@ class TileWidgets extends ChangeNotifier {
       }
       _idToModel[tile] = model;
     }
-    if (substituteTilesWhileLoading && _loadingModels.isNotEmpty) {
+    if (maxSubstitutionDifference > 0 && _loadingModels.isNotEmpty) {
       _substitutionModels =
           _substitutionTiles(previousIdToModel, _loadingModels);
       for (final model in _idToModel.values) {
@@ -196,7 +196,7 @@ class TileWidgets extends ChangeNotifier {
           .where((candidate) => loadingModels.any((m) {
                 final zoomDiff = (m.tile.z - candidate.tile.z).abs();
                 return zoomDiff > 0 &&
-                    zoomDiff <= _maxSubstitutionDifference &&
+                    zoomDiff <= maxSubstitutionDifference &&
                     m.tile.overlaps(candidate.tile);
               }))
           .toList();
@@ -209,5 +209,3 @@ class TileWidgets extends ChangeNotifier {
     obsolete.dispose();
   }
 }
-
-const _maxSubstitutionDifference = 2;

--- a/lib/src/grid/tile_widgets.dart
+++ b/lib/src/grid/tile_widgets.dart
@@ -26,6 +26,7 @@ class TileWidgets extends ChangeNotifier {
   final bool paintBackground;
   final bool showTileDebugInfo;
   final int maxSubstitutionDifference;
+  final int tileZoomSubstitutionOffset;
 
   TileWidgets(
       this._zoomScaleFunction,
@@ -36,6 +37,7 @@ class TileWidgets extends ChangeNotifier {
       this._tileProvider,
       this._textCache,
       this.maxSubstitutionDifference,
+      this.tileZoomSubstitutionOffset,
       this.paintBackground,
       this.showTileDebugInfo);
 
@@ -78,6 +80,7 @@ class TileWidgets extends ChangeNotifier {
             _theme,
             _symbolTheme,
             tile,
+            tileZoomSubstitutionOffset,
             _zoomScaleFunction,
             _zoomFunction,
             _zoomDetailFunction,

--- a/lib/src/grid/tile_zoom.dart
+++ b/lib/src/grid/tile_zoom.dart
@@ -1,0 +1,43 @@
+import '../tile_identity.dart';
+
+class TileZoom {
+  final double zoom;
+  final double zoomDetail;
+  final double zoomScale;
+
+  TileZoom(
+      {required this.zoom, required this.zoomDetail, required this.zoomScale});
+
+  factory TileZoom.undefined() => TileZoom(
+      zoom: double.negativeInfinity,
+      zoomDetail: double.negativeInfinity,
+      zoomScale: double.negativeInfinity);
+
+  @override
+  operator ==(other) =>
+      other is TileZoom &&
+      other.zoom == zoom &&
+      other.zoomDetail == zoomDetail &&
+      other.zoomScale == zoomScale;
+
+  @override
+  int get hashCode => Object.hash(zoom, zoomDetail, zoomScale);
+}
+
+typedef ZoomScaleFunction = double Function(int tileZoom);
+typedef ZoomFunction = double Function();
+
+class TileZoomProvider {
+  final TileIdentity tile;
+  final ZoomScaleFunction zoomScaleFunction;
+  final ZoomFunction zoomFunction;
+  final ZoomFunction zoomDetailFunction;
+
+  TileZoomProvider(this.tile, this.zoomScaleFunction, this.zoomFunction,
+      this.zoomDetailFunction);
+
+  TileZoom provide() => TileZoom(
+      zoom: zoomFunction(),
+      zoomDetail: zoomDetailFunction(),
+      zoomScale: zoomScaleFunction(tile.z));
+}

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -73,7 +73,7 @@ class VectorTileLayerOptions extends LayerOptions {
   final int maximumTileSubstitutionDifference;
 
   /// the default [maximumTileSubstitutionDifference]
-  static const DEFAULT_MAX_TILE_SUBSTITUTION_DIFFERENCE = 2;
+  static const DEFAULT_MAX_TILE_SUBSTITUTION_DIFFERENCE = 1;
 
   /// The default [concurrency]
   static const DEFAULT_CONCURRENCY = 4;

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -76,7 +76,7 @@ class VectorTileLayerOptions extends LayerOptions {
 
   /// The maximum zoom difference when substituting tiles while overlapping tiles
   /// are loading. A higher zoom difference results in lower chance of a blank map
-  /// while loading tiles to display. A larger zoom difference trequires more
+  /// while loading tiles to display. A larger zoom difference requires more
   /// memory and can result in an application exceeding available memory, resulting
   /// in a crash. To avoid substituting tiles, use a value of 0.
   final int maximumTileSubstitutionDifference;

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -3,8 +3,8 @@
 import 'package:flutter_map/plugin_api.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
-import '../vector_map_tiles.dart';
 import './extensions.dart';
+import '../vector_map_tiles.dart';
 
 /// a [FlutterMap] layer options, to be used with [VectorMapTilesPlugin].
 /// See the readme for details.
@@ -66,7 +66,7 @@ class VectorTileLayerOptions extends LayerOptions {
   final int concurrency;
 
   /// The default [concurrency]
-  static const DEFAULT_CONCURRENCY = 2;
+  static const DEFAULT_CONCURRENCY = 4;
 
   /// The tile offset, defaults to [TileOffset.DEFAULT].
   /// See [TileOffset.mapbox]

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -73,7 +73,7 @@ class VectorTileLayerOptions extends LayerOptions {
   final int maximumTileSubstitutionDifference;
 
   /// the default [maximumTileSubstitutionDifference]
-  static const DEFAULT_MAX_TILE_SUBSTITUTION_DIFFERENCE = 1;
+  static const DEFAULT_MAX_TILE_SUBSTITUTION_DIFFERENCE = 2;
 
   /// The default [concurrency]
   static const DEFAULT_CONCURRENCY = 4;

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -65,6 +65,16 @@ class VectorTileLayerOptions extends LayerOptions {
   /// This setting has no effect in debug mode.
   final int concurrency;
 
+  /// The maximum zoom difference when substituting tiles while overlapping tiles
+  /// are loading. A higher zoom difference results in lower chance of a blank map
+  /// while loading tiles to display. A larger zoom difference trequires more
+  /// memory and can result in an application exceeding available memory, resulting
+  /// in a crash. To avoid substituting tiles, use a value of 0.
+  final int maximumTileSubstitutionDifference;
+
+  /// the default [maximumTileSubstitutionDifference]
+  static const DEFAULT_MAX_TILE_SUBSTITUTION_DIFFERENCE = 2;
+
   /// The default [concurrency]
   static const DEFAULT_CONCURRENCY = 4;
 
@@ -81,6 +91,8 @@ class VectorTileLayerOptions extends LayerOptions {
       this.textCacheMaxSize = DEFAULT_TEXT_CACHE_MAX_SIZE,
       this.concurrency = DEFAULT_CONCURRENCY,
       this.tileOffset = TileOffset.DEFAULT,
+      this.maximumTileSubstitutionDifference =
+          DEFAULT_MAX_TILE_SUBSTITUTION_DIFFERENCE,
       this.backgroundTheme,
       this.showTileDebugInfo = false,
       this.logCacheStats = false,
@@ -98,6 +110,10 @@ required by the theme.
 The theme uses the following sources: ${theme.tileSources.toList().sorted().join(', ')}.
 '''
             .trim());
+    assert(
+        maximumTileSubstitutionDifference >= 0 &&
+            maximumTileSubstitutionDifference <= 3,
+        'maximumTileSubstitutionDifference must be >= 0 and <= 3');
   }
 }
 

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -40,6 +40,15 @@ class VectorTileLayerOptions extends LayerOptions {
   /// the default [memoryTileCacheMaxSize]
   static const DEFAULT_TILE_CACHE_MAX_SIZE = 1024 * 1024 * 10;
 
+  /// The maximum size in tiles of the memory vector tile cache.
+  /// Differs from [memoryTileCacheMaxSize] in that this is the cache
+  /// of parsed vector tiles, whereas [memoryTileCacheMaxSize] is the raw
+  /// tile data.
+  final int memoryTileDataCacheMaxSize;
+
+  /// the default [memoryTileDataCacheMaxSize]
+  static const DEFAULT_TILE_DATA_CACHE_MAX_SIZE = 20;
+
   /// The maximum size of the text cache.
   final int textCacheMaxSize;
 
@@ -87,6 +96,7 @@ class VectorTileLayerOptions extends LayerOptions {
       required this.theme,
       this.fileCacheTtl = DEFAULT_CACHE_TTL,
       this.memoryTileCacheMaxSize = DEFAULT_TILE_CACHE_MAX_SIZE,
+      this.memoryTileDataCacheMaxSize = DEFAULT_TILE_DATA_CACHE_MAX_SIZE,
       this.fileCacheMaximumSizeInBytes = DEFAULT_CACHE_MAX_SIZE,
       this.textCacheMaxSize = DEFAULT_TEXT_CACHE_MAX_SIZE,
       this.concurrency = DEFAULT_CONCURRENCY,
@@ -114,6 +124,7 @@ The theme uses the following sources: ${theme.tileSources.toList().sorted().join
         maximumTileSubstitutionDifference >= 0 &&
             maximumTileSubstitutionDifference <= 3,
         'maximumTileSubstitutionDifference must be >= 0 and <= 3');
+    assert(memoryTileDataCacheMaxSize >= 0 && memoryTileDataCacheMaxSize < 100);
   }
 }
 

--- a/lib/src/stream/caches_tile_provider.dart
+++ b/lib/src/stream/caches_tile_provider.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import '../tile_identity.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
 import '../cache/caches.dart';

--- a/lib/src/stream/caches_tile_provider.dart
+++ b/lib/src/stream/caches_tile_provider.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 
-import 'tile_processor.dart';
-import 'tileset_ui_preprocessor.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
 import '../cache/caches.dart';
+import 'tile_processor.dart';
 import 'tile_supplier.dart';
 import 'tileset_executor_preprocessor.dart';
+import 'tileset_ui_preprocessor.dart';
 
 class CachesTileProvider extends TileProvider {
   final Caches _caches;

--- a/lib/src/stream/delay_provider.dart
+++ b/lib/src/stream/delay_provider.dart
@@ -1,5 +1,7 @@
 import 'dart:math';
 
+import '../tile_identity.dart';
+
 import 'tile_supplier.dart';
 
 class DelayProvider extends TileProvider {
@@ -27,4 +29,8 @@ class DelayProvider extends TileProvider {
     await Future.delayed(durationWithJitter);
     return tile;
   }
+
+  @override
+  Future<TileResponse> provideLocalCopy(TileRequest request) =>
+      _delegate.provideLocalCopy(request);
 }

--- a/lib/src/stream/delay_provider.dart
+++ b/lib/src/stream/delay_provider.dart
@@ -1,7 +1,5 @@
 import 'dart:math';
 
-import '../tile_identity.dart';
-
 import 'tile_supplier.dart';
 
 class DelayProvider extends TileProvider {

--- a/lib/src/stream/tile_supplier.dart
+++ b/lib/src/stream/tile_supplier.dart
@@ -43,4 +43,5 @@ class TileResponse {
 abstract class TileProvider {
   int get maximumZoom;
   Future<TileResponse> provide(TileRequest request);
+  Future<TileResponse> provideLocalCopy(TileRequest request);
 }

--- a/lib/src/stream/tileset_ui_preprocessor.dart
+++ b/lib/src/stream/tileset_ui_preprocessor.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 import 'dart:math';
 
-import '../executor/queue_executor.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
 import '../../vector_map_tiles.dart';
 import '../executor/executor.dart';
+import '../executor/queue_executor.dart';
 
 class TilesetUiPreprocessor {
   final TilesetPreprocessor _preprocessor;

--- a/lib/src/stream/translated_tile_request.dart
+++ b/lib/src/stream/translated_tile_request.dart
@@ -1,0 +1,30 @@
+import 'dart:math';
+
+import '../grid/slippy_map_translator.dart';
+import '../tile_identity.dart';
+import 'tile_supplier.dart';
+
+TileRequest createTranslatedRequest(TileRequest request,
+    {required int maximumZoom}) {
+  TileIdentity tileId = request.tileId;
+  if (tileId.z > maximumZoom) {
+    final translator = SlippyMapTranslator(maximumZoom);
+    final translation =
+        translator.specificZoomTranslation(tileId, zoom: maximumZoom);
+    tileId = translation.translated;
+    const tileSize = 256;
+    final clipSize = tileSize / translation.fraction;
+    const buffer = 10;
+    final dx = (translation.xOffset * clipSize) - buffer;
+    final dy = (translation.yOffset * clipSize) - buffer;
+    final sizeWithBuffer = (2 * buffer) + clipSize;
+    final clip = Rectangle(dx, dy, sizeWithBuffer, sizeWithBuffer);
+    return TileRequest(
+        tileId: tileId,
+        zoom: request.zoom,
+        zoomDetail: request.zoomDetail,
+        clip: clip,
+        cancelled: request.cancelled);
+  }
+  return request;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -535,7 +535,7 @@ packages:
       name: vector_tile_renderer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.8"
+    version: "2.5.9"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -535,7 +535,7 @@ packages:
       name: vector_tile_renderer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.9"
+    version: "2.6.2"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   http: ^0.13.3
   latlong2: ^0.8.0
   path_provider: ^2.0.2
-  vector_tile_renderer: ^2.5.8
+  vector_tile_renderer: ^2.5.9
     #path: ../vector_tile_renderer
   async: ^2.8.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   http: ^0.13.3
   latlong2: ^0.8.0
   path_provider: ^2.0.2
-  vector_tile_renderer: ^2.5.9
+  vector_tile_renderer: ^2.6.2
     #path: ../vector_tile_renderer
   async: ^2.8.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_map_tiles
 description: A plugin for `flutter_map` that enables the use of vector tiles.
-version: 2.3.0
+version: 2.4.0
 homepage: https://github.com/greensopinion/flutter-vector-map-tiles
 
 environment:

--- a/test/src/slippy_map_translator_test.dart
+++ b/test/src/slippy_map_translator_test.dart
@@ -77,4 +77,23 @@ void main() {
     expect(translation.xOffset, 0);
     expect(translation.yOffset, 1);
   });
+
+  test('provides an alternative at zoom', () {
+    final translator = SlippyMapTranslator(14);
+    final tile = TileIdentity(8, 41, 88);
+    final expected = <int, TileIdentity>{
+      8: tile,
+      7: TileIdentity(7, 20, 44),
+      6: TileIdentity(6, 10, 22),
+      5: TileIdentity(5, 5, 11),
+      4: TileIdentity(4, 2, 5),
+      3: TileIdentity(3, 1, 2),
+      2: TileIdentity(2, 0, 1),
+      1: TileIdentity(1, 0, 0)
+    };
+    for (int z = 8; z >= 1; --z) {
+      final alternative = translator.specificZoomTranslation(tile, zoom: z);
+      expect(alternative.translated, expected[z]);
+    }
+  });
 }


### PR DESCRIPTION
Load tile substitutions from the cache
when available. This makes the map
display map data more quickly in cases
where higher zoom tiles are available
locally, especially when there is no
internet connection or the connection
is slow.

Trim polygons when overzooming. This
avoids excessive memory usage when 
overzooming, reducing the chances of
a crash.

Add experimental layers feature which
enables delayed painting of theme layers.
Theme layers are split into Flutter layers
which provides some flexibility in timing.
Expensive layers can be invisible and
delayed while loading or zooming, rendering
at a later time. This makes the initial
rendering faster, and can help to eliminate
jank while zooming. Having additional layers
may contribute to higher memory usage.

