### PR TITLE
limit raster tile rendering concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.2
+
+* limit raster tile rendering concurrency
+
 ## 3.3.1
 
 * fix issue where tiles would not dynamically change when theme changed

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: executor_lib
-      sha256: "195ea4b3b7bf3cb6c7a1930f0649d87afeb178ccf0628986c2d0661aa0263db2"
+      sha256: "49696532000c21a6201f768d34cd69e93afe8add4e621d52b5c1df6d3b907159"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -422,7 +422,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.3.1"
+    version: "3.3.2"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/grid/grid_layer.dart
+++ b/lib/src/grid/grid_layer.dart
@@ -122,8 +122,8 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
     final layers = <Widget>[];
     if (options.layerMode == VectorTileLayerMode.raster) {
       final maxZoom = options.maximumZoom ?? 18;
-      final tileProvider = createRasterTileProvider(
-          theme, _caches, _executor, options.tileOffset, options.tileDelay);
+      final tileProvider = createRasterTileProvider(theme, _caches, _executor,
+          options.tileOffset, options.tileDelay, options.concurrency);
       final hasBackground = theme.layers
           .where((layer) => layer.type == ThemeLayerType.background)
           .isNotEmpty;
@@ -131,6 +131,7 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
           key: Key("${theme.id}_v${theme.version}_VectorTileLayer"),
           maxZoom: maxZoom,
           maxNativeZoom: maxZoom,
+          evictErrorTileStrategy: EvictErrorTileStrategy.notVisible,
           backgroundColor: hasBackground
               ? material.Theme.of(context).canvasColor
               : const Color.fromARGB(0, 0, 0, 0),

--- a/lib/src/raster/raster_tile_provider.dart
+++ b/lib/src/raster/raster_tile_provider.dart
@@ -14,8 +14,13 @@ import 'future_tile_provider.dart';
 import 'storage_image_cache.dart';
 import 'tile_loader.dart';
 
-TileProvider createRasterTileProvider(Theme theme, Caches caches,
-    Executor executor, TileOffset tileOffset, Duration tileDelay) {
+TileProvider createRasterTileProvider(
+    Theme theme,
+    Caches caches,
+    Executor executor,
+    TileOffset tileOffset,
+    Duration tileDelay,
+    int concurrency) {
   final tileSupplier = TranslatingTileProvider(DelayProvider(
           CachesTileProvider(
               caches,
@@ -27,6 +32,6 @@ TileProvider createRasterTileProvider(Theme theme, Caches caches,
       .orDelegate());
   return FutureTileProvider(
       loader: TileLoader(theme, tileSupplier, tileOffset,
-              StorageImageCache(theme, caches.storageCache))
+              StorageImageCache(theme, caches.storageCache), concurrency)
           .loadTile);
 }

--- a/lib/src/raster/tile_loader.dart
+++ b/lib/src/raster/tile_loader.dart
@@ -1,26 +1,39 @@
+import 'dart:async';
 import 'dart:math';
 import 'dart:ui';
 
+import 'package:executor_lib/executor_lib.dart';
 import 'package:flutter/widgets.dart' hide Image;
 import 'package:flutter_map/plugin_api.dart';
-import 'package:vector_map_tiles/src/stream/translated_tile_request.dart';
-import 'storage_image_cache.dart';
+import 'package:vector_tile_renderer/vector_tile_renderer.dart' hide TileLayer;
+
+import '../../vector_map_tiles.dart';
 import '../grid/grid_tile_positioner.dart';
 import '../grid/slippy_map_translator.dart';
 import '../stream/tile_supplier.dart';
+import '../stream/translated_tile_request.dart';
 import '../stream/translating_tile_provider.dart';
-import '../../vector_map_tiles.dart';
-import 'package:vector_tile_renderer/vector_tile_renderer.dart' hide TileLayer;
+import 'storage_image_cache.dart';
 
 class TileLoader {
   final Theme _theme;
   final TranslatingTileProvider _provider;
   final StorageImageCache _imageCache;
   final TileOffset _tileOffset;
+  final int _concurrency;
+  final _scale = 2.0;
+  late final ConcurrencyExecutor _jobQueue;
 
-  TileLoader(this._theme, this._provider, this._tileOffset, this._imageCache);
+  TileLoader(this._theme, this._provider, this._tileOffset, this._imageCache,
+      this._concurrency) {
+    _jobQueue = ConcurrencyExecutor(
+        delegate: ImmediateExecutor(),
+        concurrencyLimit: _concurrency * 2,
+        maxQueueSize: _maxOutstandingJobs);
+  }
 
-  Future<ImageInfo> loadTile(Coords<num> coords, TileLayer options) async {
+  Future<ImageInfo> loadTile(
+      Coords<num> coords, TileLayer options, bool Function() cancelled) async {
     final requestedTile =
         TileIdentity(coords.z.toInt(), coords.x.toInt(), coords.y.toInt());
     var requestZoom = requestedTile.z;
@@ -28,20 +41,32 @@ class TileLoader {
       requestZoom = max(
           1, min(requestZoom + _tileOffset.zoomOffset, _provider.maximumZoom));
     }
-    final translator = SlippyMapTranslator(_provider.maximumZoom);
-    const scale = 2.0;
-
-    var translation = translator.translate(requestedTile);
-    final cached = await _imageCache.retrieve(translation.original);
+    final cached = await _imageCache.retrieve(requestedTile);
     if (cached != null) {
-      return ImageInfo(image: cached, scale: scale);
+      return ImageInfo(image: cached, scale: _scale);
     }
+    final job =
+        _TileJob(requestedTile, requestZoom, options.tileSize, cancelled);
+    return _jobQueue.submit(Job<_TileJob, ImageInfo>(
+        'render $requestedTile', _renderJob, job,
+        deduplicationKey: 'render $requestedTile'));
+  }
 
+  Future<ImageInfo> _renderJob(job) => _renderTile(
+      job.requestedTile, job.requestZoom, job.tileSize, job.cancelled);
+
+  Future<ImageInfo> _renderTile(TileIdentity requestedTile, int requestZoom,
+      double tileSize, bool Function() cancelled) async {
+    if (cancelled()) {
+      throw CancellationException();
+    }
+    final translator = SlippyMapTranslator(_provider.maximumZoom);
+    var translation = translator.translate(requestedTile);
     final originalRequest = TileRequest(
         tileId: requestedTile,
         zoom: requestedTile.z.toDouble(),
         zoomDetail: requestedTile.z.toDouble(),
-        cancelled: () => false);
+        cancelled: cancelled);
     final translatedRequest =
         createTranslatedRequest(originalRequest, maximumZoom: requestZoom);
 
@@ -55,22 +80,25 @@ class TileLoader {
           zoom: tileResponse.identity.z);
     }
 
-    final tileSize = options.tileSize;
-    final size = tileSize * scale;
-    final tileSizer = GridTileSizer(translation, scale, Size.square(size));
+    final size = tileSize * _scale;
+    final tileSizer = GridTileSizer(translation, _scale, Size.square(size));
 
     final rect = Rect.fromLTRB(0, 0, size, size);
+
+    if (cancelled()) {
+      throw CancellationException();
+    }
 
     final recorder = PictureRecorder();
     final canvas = Canvas(recorder, rect);
     canvas.clipRect(rect);
     double zoomScaleFactor;
     if (tileSizer.effectiveScale == 1.0) {
-      canvas.scale(scale.toDouble(), scale.toDouble());
-      zoomScaleFactor = scale;
+      canvas.scale(_scale, _scale);
+      zoomScaleFactor = _scale;
     } else {
       tileSizer.apply(canvas);
-      zoomScaleFactor = tileSizer.effectiveScale / scale;
+      zoomScaleFactor = tileSizer.effectiveScale / _scale;
     }
     final tileClip =
         tileSizer.tileClip(Size.square(size), tileSizer.effectiveScale);
@@ -82,11 +110,11 @@ class TileLoader {
 
     final picture = recorder.endRecording();
     final image = await picture.toImage(size.toInt(), size.toInt());
-    _cache(translation.original, image);
-    return ImageInfo(image: image, scale: scale);
+    await _cache(translation.original, image);
+    return ImageInfo(image: image, scale: _scale);
   }
 
-  void _cache(TileIdentity tile, Image image) async {
+  Future<void> _cache(TileIdentity tile, Image image) async {
     Image cloned = image.clone();
     try {
       await _imageCache.put(tile, cloned);
@@ -97,3 +125,14 @@ class TileLoader {
     }
   }
 }
+
+class _TileJob {
+  final TileIdentity requestedTile;
+  final int requestZoom;
+  final double tileSize;
+  final bool Function() cancelled;
+
+  _TileJob(this.requestedTile, this.requestZoom, this.tileSize, this.cancelled);
+}
+
+int _maxOutstandingJobs = 50;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: "direct main"
     description:
       name: executor_lib
-      sha256: "195ea4b3b7bf3cb6c7a1930f0649d87afeb178ccf0628986c2d0661aa0263db2"
+      sha256: "49696532000c21a6201f768d34cd69e93afe8add4e621d52b5c1df6d3b907159"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   ffi:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_map_tiles
 description: A plugin for `flutter_map` that enables the use of vector tiles.
-version: 3.3.1
+version: 3.3.2
 homepage: https://github.com/greensopinion/flutter-vector-map-tiles
 
 environment:
@@ -18,7 +18,8 @@ dependencies:
   vector_tile_renderer: ^3.2.0
     #path: ../vector_tile_renderer
   async: ^2.8.2
-  executor_lib: ^1.0.0
+  executor_lib: ^1.1.0
+    #path: ../executor_lib
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
Limit concurrency to the specified level
and render tiles in LIFO order. This makes
tiles more responsive.

Discard oldest items if the tile queue
gets too large since these are unlikely
to be useful. If the user scrolls quickly
we can end up with a large backlog of
wasteful work. The queue limit is somewhat
arbitrary, in the future we may want to
improve the algorithm by checking to see
if requested tiles are in the visible
region.