### PR TITLE
 eliminate noise from disposed ImageStreamCompleter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 6.0.1
+
+* eliminate noise from disposed `ImageStreamCompleter` since it's expected
+
 ## 6.0.0
 
 * support icon/text rotation to align with viewport

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_map_tiles
 description: A plugin for `flutter_map` that enables the use of vector tiles.
-version: 6.0.0
+version: 6.0.1
 homepage: https://github.com/greensopinion/flutter-vector-map-tiles
 
 environment:


### PR DESCRIPTION
it is expected that the completer might be disposed before the image has finished loading

this fixes a potential leak