### PR TITLE
Improve tile storage and make VectorTileLayer work on Web.

### DIFF
--- a/lib/src/cache/byte_storage.dart
+++ b/lib/src/cache/byte_storage.dart
@@ -1,60 +1,224 @@
 import 'dart:io';
 import 'dart:typed_data';
+import 'dart:collection';
+
+abstract class ByteStorage {
+  Future<bool> exists(String path);
+  Future<void> write(String path, Uint8List bytes);
+  Future<Uint8List?> read(String path);
+  Future<void> delete(String path);
+
+  Future<void> enforceSize();
+  Future<void> enforceTtl();
+}
 
 typedef PathFunction = Future<Directory> Function();
 
-class ByteStorage {
+class FileSystemByteStorage implements ByteStorage {
   final PathFunction _pather;
+  final int _maxSizeInBytes;
+  final Duration _ttl;
+
   String? _path;
+  DateTime? _oldestValid;
 
-  ByteStorage._withPath(this._pather);
-
-  ByteStorage({required PathFunction pather}) : this._withPath(pather);
+  FileSystemByteStorage({
+    required PathFunction pather,
+    required int maxSizeInBytes,
+    required Duration ttl,
+  })  : _pather = pather,
+        _maxSizeInBytes = maxSizeInBytes,
+        _ttl = ttl;
 
   Future<String> get _storagePath async {
-    String? path = _path;
-    if (path == null) {
+    String path = _path ??= await () async {
       final directory = await _pather();
       final exists = await directory.exists();
       if (!exists) {
         await directory.create(recursive: true);
       }
-      path = directory.path;
-      _path = path;
-    }
+      return directory.path;
+    }();
     return path;
   }
 
-  Future<File> fileOf(String path) async {
+  @override
+  Future<bool> exists(String path) async {
     final root = await _storagePath;
-    return File("$root/$path");
+    return await File("$root/$path").exists();
   }
 
-  Future<Directory> storageDirectory() async {
-    final root = await _storagePath;
-    return Directory(root);
-  }
-
+  @override
   Future<void> write(String path, Uint8List bytes) async {
-    final file = await fileOf(path);
+    final file = await _fileOf(path);
     if (!await file.parent.exists()) {
       await file.parent.create(recursive: true);
     }
     await file.writeAsBytes(bytes);
   }
 
+  @override
   Future<Uint8List?> read(String path) async {
-    final file = await fileOf(path);
+    final file = await _fileOf(path);
     if (await file.exists()) {
       return file.readAsBytes();
     }
     return null;
   }
 
+  @override
   Future<void> delete(String path) async {
-    final file = await fileOf(path);
+    final file = await _fileOf(path);
     if (await file.exists()) {
       await file.delete();
     }
+  }
+
+  @override
+  Future<void> enforceSize() async {
+    final directory = Directory(await _storagePath);
+    final entries = await directory
+        .list()
+        .asyncMap((f) async => MapEntry(f, await f.stat()))
+        .where((e) => e.value.type == FileSystemEntityType.file)
+        .toList();
+    int size = entries.isEmpty
+        ? 0
+        : entries.map((e) => e.value.size).reduce((a, b) => a + b);
+    if (size <= _maxSizeInBytes) {
+      return;
+    }
+
+    entries.sort((a, b) => a.value.accessed.compareTo(b.value.accessed));
+    for (final entry in entries) {
+      try {
+        await entry.key.delete();
+        size -= entry.value.size;
+        if (size <= _maxSizeInBytes) {
+          return;
+        }
+      } catch (e) {
+        // ignore, race condition file was deleted
+      }
+    }
+  }
+
+  @override
+  Future<void> enforceTtl() async {
+    final now = DateTime.now();
+    if (_oldestValid != null && now.difference(_oldestValid!) <= _ttl) {
+      return;
+    }
+
+    final root = Directory(await _storagePath);
+    final deletions = <Future>[];
+    await for (final f in root.list()) {
+      deletions.add(_expireIfExceedsTtl(now, f));
+    }
+    await Future.wait(deletions);
+  }
+
+  Future<void> _expireIfExceedsTtl(
+    DateTime now,
+    FileSystemEntity entity,
+  ) async {
+    final stat = await entity.stat();
+    if (stat.type != FileSystemEntityType.file) {
+      return;
+    }
+
+    final expired = now.difference(stat.modified) > _ttl;
+    if (expired) {
+      await entity.delete();
+    } else if (_oldestValid == null || stat.modified.isBefore(_oldestValid!)) {
+      _oldestValid = stat.modified;
+    }
+  }
+
+  Future<File> _fileOf(String path) async {
+    final root = await _storagePath;
+    return File("$root/$path");
+  }
+}
+
+class _CacheEntry {
+  final Uint8List _data;
+  final DateTime created;
+  late DateTime accessed;
+
+  _CacheEntry(this._data) : created = DateTime.now() {
+    accessed = created;
+  }
+
+  Uint8List get data {
+    accessed = DateTime.now();
+    return _data;
+  }
+}
+
+class InMemoryByteStorage extends ByteStorage {
+  final HashMap<String, _CacheEntry> _store;
+  final int _maxSizeInBytes;
+  final Duration _ttl;
+
+  InMemoryByteStorage({
+    required int maxSizeInBytes,
+    required Duration ttl,
+  })  : _store = HashMap<String, _CacheEntry>(),
+        _maxSizeInBytes = maxSizeInBytes,
+        _ttl = ttl;
+
+  @override
+  Future<bool> exists(String path) async {
+    return _store.containsKey(path);
+  }
+
+  @override
+  Future<void> write(String path, Uint8List bytes) async {
+    _store[path] = _CacheEntry(bytes);
+  }
+
+  @override
+  Future<Uint8List?> read(String path) async {
+    final entry = _store[path];
+    if (entry == null) {
+      return null;
+    }
+    return entry.data;
+  }
+
+  @override
+  Future<bool> delete(String path) async {
+    return _store.remove(path) != null;
+  }
+
+  @override
+  Future<void> enforceSize() async {
+    int size = 0;
+    final entries = _store.entries.map((entry) {
+      final len = entry.value._data.length;
+      size += len;
+      return (entry.key, entry.value.accessed, len);
+    }).toList(growable: false);
+
+    if (size <= _maxSizeInBytes) {
+      return;
+    }
+
+    entries.sort((a, b) => a.$2.compareTo(b.$2));
+    for (final entry in entries) {
+      _store.remove(entry.$1);
+      size -= entry.$3;
+
+      if (size <= _maxSizeInBytes) {
+        return;
+      }
+    }
+  }
+
+  @override
+  Future<void> enforceTtl() async {
+    final now = DateTime.now();
+    _store.removeWhere((_, entry) => now.difference(entry.created) > _ttl);
   }
 }

--- a/lib/src/cache/storage_cache.dart
+++ b/lib/src/cache/storage_cache.dart
@@ -1,17 +1,13 @@
-import 'dart:io';
 import 'dart:typed_data';
 
-import '../extensions.dart';
 import 'byte_storage.dart';
 import 'cache_stats.dart';
 
 class StorageCache with CacheStats {
   final ByteStorage _storage;
-  final Duration _ttl;
-  final int _maxSizeInBytes;
   int _putCount = 0;
 
-  StorageCache(this._storage, this._ttl, this._maxSizeInBytes);
+  StorageCache(this._storage);
 
   Future<void> remove(String key) async {
     await _storage.delete(key);
@@ -34,77 +30,17 @@ class StorageCache with CacheStats {
 
   Future<void> put(String key, Uint8List data) async {
     if (++_putCount % 20 == 0) {
-      await _applyMaxSize(await _storage.storageDirectory());
+      await _storage.enforceSize();
     }
     await _storage.write(key, data);
   }
 
   Future<bool> exists(String key) async {
-    final file = await _storage.fileOf(key);
-    return file.exists();
+    return await _storage.exists(key);
   }
 
   Future<void> applyConstraints() async {
-    final directory = await _storage.storageDirectory();
-    if (await directory.exists()) {
-      try {
-        await _applyMaxAge(directory);
-        await _applyMaxSize(directory);
-      } catch (e) {
-        // ignore, race condition directory may have been deleted
-      }
-    }
-  }
-
-  Future<void> _applyMaxAge(Directory directory) async {
-    await directory.list().asyncMap((f) => _expireIfExceedsTtl(f)).toList();
-  }
-
-  Future<void> _applyMaxSize(Directory directory) async {
-    final entries = await directory
-        .list()
-        .asyncMap((f) => _toEntry(f))
-        .where((e) => e.value.type == FileSystemEntityType.file)
-        .toList();
-    int size = entries.isEmpty
-        ? 0
-        : entries.map((e) => e.value.size).reduce((a, b) => a + b);
-    if (size > _maxSizeInBytes) {
-      final entriesByAccessed = entries
-          .sorted((a, b) => a.value.accessed.compareTo(b.value.accessed));
-      for (final entry in entriesByAccessed) {
-        try {
-          await entry.key.delete();
-          size -= entry.value.size;
-          if (size <= _maxSizeInBytes) {
-            break;
-          }
-        } catch (e) {
-          // ignore, race condition file was deleted
-        }
-      }
-    }
-  }
-
-  Future<void> _expireIfExceedsTtl(FileSystemEntity entity) async {
-    final stat = await entity.stat();
-    if (stat.type == FileSystemEntityType.file) {
-      final exceeds = _exceedsTtl(stat);
-      if (exceeds) {
-        await entity.delete();
-      }
-    }
-  }
-
-  bool _exceedsTtl(FileStat stat) {
-    final now = DateTime.now();
-    final age =
-        now.millisecondsSinceEpoch - stat.modified.millisecondsSinceEpoch;
-    return (age >= _ttl.inMilliseconds);
-  }
-
-  Future<MapEntry<FileSystemEntity, FileStat>> _toEntry(
-      FileSystemEntity entity) async {
-    return MapEntry(entity, await entity.stat());
+    await _storage.enforceTtl();
+    await _storage.enforceSize();
   }
 }

--- a/lib/src/vector_tile_layer.dart
+++ b/lib/src/vector_tile_layer.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart' hide Theme;
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_map/flutter_map.dart';
 import 'style/style.dart';
 import 'vector_tile_layer_mode.dart';
@@ -98,7 +99,7 @@ class VectorTileLayer extends StatelessWidget {
   static const defaultMaxTileSubstitutionDifference = 2;
 
   /// The default [concurrency]
-  static const defaultConcurrency = 4;
+  static const defaultConcurrency = kIsWeb ? 0 : 4;
 
   /// The tile offset, defaults to [TileOffset.DEFAULT].
   /// See [TileOffset.mapbox].

--- a/test/src/cache/storage_cache_test.dart
+++ b/test/src/cache/storage_cache_test.dart
@@ -22,83 +22,104 @@ void main() {
     await folder?.delete(recursive: true);
   });
 
-  StorageCache newCache(
-          {Duration ttl = const Duration(minutes: 1),
-          int maxSize = 1024 * 10}) =>
-      StorageCache(ByteStorage(pather: () async => folder!), ttl, maxSize);
+  StorageCache newFileSystemCache({
+    Duration ttl = const Duration(minutes: 1),
+    int maxSize = 1024 * 10,
+  }) =>
+      StorageCache(FileSystemByteStorage(
+        pather: () async => folder!,
+        ttl: ttl,
+        maxSizeInBytes: maxSize,
+      ));
 
-  test('caches an entry', () async {
-    final cache = newCache();
-    await cache.put(key, data);
-    expect(await cache.exists(key), true);
-    expect(await cache.retrieve(key), data);
-  });
+  StorageCache newInMemoryCache({
+    Duration ttl = const Duration(minutes: 1),
+    int maxSize = 1024 * 10,
+  }) =>
+      StorageCache(InMemoryByteStorage(ttl: ttl, maxSizeInBytes: maxSize));
 
-  test('caches an entry persistently', () async {
-    final cache = newCache();
-    await cache.put(key, data);
-    final anotherCache = newCache();
-    expect(await anotherCache.exists(key), true);
-    expect(await anotherCache.retrieve(key), data);
-  });
-
-  test('removes an entry', () async {
-    final cache = newCache();
-    await cache.put(key, data);
-    expect(await cache.exists(key), true);
-    await cache.remove(key);
-    expect(await cache.exists(key), false);
-  });
-
-  test('retrieves a non-existent entry', () async {
-    final cache = newCache();
-    const nonExistentKey = 'no-such-entry';
-    expect(await cache.exists(nonExistentKey), false);
-    await cache.remove(nonExistentKey);
-    expect(await cache.exists(nonExistentKey), false);
-  });
-
-  test('applies constraints when the folder is deleted', () async {
-    final cache = newCache();
-    await folder?.delete(recursive: true);
-    await cache.applyConstraints();
-  });
-  test('applies constraints leaving data in the cache', () async {
-    final cache = newCache();
-    await cache.put(key, data);
-    await cache.applyConstraints();
-    expect(await cache.exists(key), true);
-    expect(await cache.retrieve(key), data);
-  });
-  test('applies constraints removing entries when ttl expires', () async {
-    const ttl = Duration(seconds: 1);
-    final cache = newCache(ttl: ttl);
-    await cache.put(key, data);
-    sleep(ttl + const Duration(milliseconds: 2));
-    await cache.put(anotherKey, data);
-    await cache.applyConstraints();
-    expect(await cache.exists(key), false);
-    expect(await cache.exists(anotherKey), true);
-    expect(await cache.retrieve(anotherKey), data);
-  });
-  test('applies constraints removing oldest entries when size is exceeded',
-      () async {
-    final cache = newCache(maxSize: data.length * 10);
-    final keys = List.generate(10, (index) => 'key-$index');
-    for (final key in keys) {
+  for (final (persistent, newCache) in [
+    (true, newFileSystemCache),
+    (false, newInMemoryCache)
+  ]) {
+    test('caches an entry', () async {
+      final cache = newCache();
       await cache.put(key, data);
+      expect(await cache.exists(key), true);
+      expect(await cache.retrieve(key), data);
+    });
+
+    if (persistent) {
+      test('caches an entry persistently', () async {
+        final cache = newCache();
+        await cache.put(key, data);
+        final anotherCache = newCache();
+        expect(await anotherCache.exists(key), true);
+        expect(await anotherCache.retrieve(key), data);
+      });
     }
-    sleep(const Duration(seconds: 1));
-    for (var x = 0; x < (keys.length - 1); ++x) {
-      await cache.retrieve(keys[x]);
-      expect(await cache.exists(keys[x]), true);
+
+    test('removes an entry', () async {
+      final cache = newCache();
+      await cache.put(key, data);
+      expect(await cache.exists(key), true);
+      await cache.remove(key);
+      expect(await cache.exists(key), false);
+    });
+
+    test('retrieves a non-existent entry', () async {
+      final cache = newCache();
+      const nonExistentKey = 'no-such-entry';
+      expect(await cache.exists(nonExistentKey), false);
+      await cache.remove(nonExistentKey);
+      expect(await cache.exists(nonExistentKey), false);
+    });
+
+    if (persistent) {
+      test('applies constraints when the folder is deleted', () async {
+        final cache = newCache();
+        await folder?.delete(recursive: true);
+        await cache.applyConstraints();
+      });
     }
-    await cache.put(anotherKey, data);
-    await cache.applyConstraints();
-    for (var x = 0; x < (keys.length - 1); ++x) {
-      expect(await cache.exists(keys[x]), true);
-    }
-    expect(await cache.exists(keys[keys.length - 1]), false);
-    expect(await cache.exists(anotherKey), true);
-  });
+
+    test('applies constraints leaving data in the cache', () async {
+      final cache = newCache();
+      await cache.put(key, data);
+      await cache.applyConstraints();
+      expect(await cache.exists(key), true);
+      expect(await cache.retrieve(key), data);
+    });
+    test('applies constraints removing entries when ttl expires', () async {
+      const ttl = Duration(seconds: 1);
+      final cache = newCache(ttl: ttl);
+      await cache.put(key, data);
+      sleep(ttl + const Duration(milliseconds: 2));
+      await cache.put(anotherKey, data);
+      await cache.applyConstraints();
+      expect(await cache.exists(key), false);
+      expect(await cache.exists(anotherKey), true);
+      expect(await cache.retrieve(anotherKey), data);
+    });
+    test('applies constraints removing oldest entries when size is exceeded',
+        () async {
+      final cache = newCache(maxSize: data.length * 10);
+      final keys = List.generate(10, (index) => 'key-$index');
+      for (final key in keys) {
+        await cache.put(key, data);
+      }
+      sleep(const Duration(seconds: 1));
+      for (var x = 0; x < (keys.length - 1); ++x) {
+        await cache.retrieve(keys[x]);
+        expect(await cache.exists(keys[x]), true);
+      }
+      await cache.put(anotherKey, data);
+      await cache.applyConstraints();
+      for (var x = 0; x < (keys.length - 1); ++x) {
+        expect(await cache.exists(keys[x]), true);
+      }
+      expect(await cache.exists(keys[keys.length - 1]), false);
+      expect(await cache.exists(anotherKey), true);
+    });
+  }
 }


### PR DESCRIPTION
Pretty straightforward change, looks worse than it is. Does 3 things:

 * Changes the BytesStore API to be byte-oriented rather than FS oriented
 * Provides a second in-memory implementation.
 * On web: use the in-memory store and set concurrency to 0 to not use isolates.

There are also some small optimizations like:

 * memoizing the oldest tile to avoid re-scanning the filesystem and allow for a quick escape.
 * do TTL deletions concurrently (we could do the same for size deletions if we're ok under-deleting in the rare case of a race :shrug:)