### PR TITLE
update(dep): upgrade flutter_map to ^7.0.2

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
     #path: ../../vector_tile_renderer
   vector_map_tiles:
     path: ../
-  flutter_map: ^6.1.0
+  flutter_map: ^7.0.2
   latlong2: ^0.9.0
 
 dev_dependencies:

--- a/lib/src/grid/grid_tile_positioner.dart
+++ b/lib/src/grid/grid_tile_positioner.dart
@@ -33,7 +33,7 @@ class GridTilePositioner {
 
   Offset _tileOffset(TileIdentity tile) {
     final tilePosition =
-        ((tile.toDoublePoint().scaleBy(tileSize) - state.origin) *
+        ((tile.toDoublePoint() * tileSize.x - state.origin) *
                 state.zoomScale) +
             state.translate;
     return Offset(tilePosition.x.toDouble(), tilePosition.y.toDouble());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_map_tiles
 description: A plugin for `flutter_map` that enables the use of vector tiles.
-version: 7.3.1
+version: 7.3.2
 homepage: https://github.com/greensopinion/flutter-vector-map-tiles
 
 environment:
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_map: ^6.1.0
+  flutter_map: ^7.0.2
   http: ^1.0.0
   latlong2: ^0.9.0
   path_provider: ^2.0.2


### PR DESCRIPTION
Upgrade flutter_map dependency from ^6.1.0 to ^7.0.2 to ensure compatibility with newer versions and fix potential issues. This change affects both the example project and the vector_map_tiles package itself.