### PR TITLE
Bugfix/atlas image cache load dispose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.0.0-beta.1
+
+* Added web support
+
 ## 8.0.0
 
 * update `flutter_map` to version 7.0.2

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -16,7 +16,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
 
 PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 

--- a/example/macos/Runner/AppDelegate.swift
+++ b/example/macos/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true

--- a/lib/src/cache/atlas_image_cache.dart
+++ b/lib/src/cache/atlas_image_cache.dart
@@ -54,12 +54,29 @@ class AtlasImageCache {
   Future<Image> _load() async {
     final key = _key();
     var bytes = await _delegate.retrieve(key);
+    if (_disposed) {
+      return Future.error(CancellationException());
+    }
     if (bytes == null) {
       bytes = await _atlasProvider();
+      if (_disposed) {
+        return Future.error(CancellationException());
+      }
       await _delegate.put(key, bytes);
     }
+    if (_disposed) {
+      return Future.error(CancellationException());
+    }
     final codec = await instantiateImageCodec(bytes);
+    if (_disposed) {
+      codec.dispose();
+      return Future.error(CancellationException());
+    }
     final frame = await codec.getNextFrame();
+    if (_disposed) {
+      frame.image.dispose();
+      return Future.error(CancellationException());
+    }
     return frame.image;
   }
 

--- a/lib/src/cache/byte_storage.dart
+++ b/lib/src/cache/byte_storage.dart
@@ -1,60 +1,22 @@
-import 'dart:io';
 import 'dart:typed_data';
 
-typedef PathFunction = Future<Directory> Function();
+abstract class ByteStorage {
+  Future<void> write(String path, Uint8List bytes);
+  Future<Uint8List?> read(String path);
+  Future<void> delete(String path);
+  Future<bool> exists(String key);
+  Future<List<ByteStorageEntry>> list();
+}
 
-class ByteStorage {
-  final PathFunction _pather;
-  String? _path;
+class ByteStorageEntry {
+  final String path;
+  final int size;
+  final DateTime modified;
+  final DateTime accessed;
 
-  ByteStorage._withPath(this._pather);
-
-  ByteStorage({required PathFunction pather}) : this._withPath(pather);
-
-  Future<String> get _storagePath async {
-    String? path = _path;
-    if (path == null) {
-      final directory = await _pather();
-      final exists = await directory.exists();
-      if (!exists) {
-        await directory.create(recursive: true);
-      }
-      path = directory.path;
-      _path = path;
-    }
-    return path;
-  }
-
-  Future<File> fileOf(String path) async {
-    final root = await _storagePath;
-    return File("$root/$path");
-  }
-
-  Future<Directory> storageDirectory() async {
-    final root = await _storagePath;
-    return Directory(root);
-  }
-
-  Future<void> write(String path, Uint8List bytes) async {
-    final file = await fileOf(path);
-    if (!await file.parent.exists()) {
-      await file.parent.create(recursive: true);
-    }
-    await file.writeAsBytes(bytes);
-  }
-
-  Future<Uint8List?> read(String path) async {
-    final file = await fileOf(path);
-    if (await file.exists()) {
-      return file.readAsBytes();
-    }
-    return null;
-  }
-
-  Future<void> delete(String path) async {
-    final file = await fileOf(path);
-    if (await file.exists()) {
-      await file.delete();
-    }
-  }
+  ByteStorageEntry(
+      {required this.path,
+      required this.size,
+      required this.modified,
+      required this.accessed});
 }

--- a/lib/src/cache/byte_storage_factory.dart
+++ b/lib/src/cache/byte_storage_factory.dart
@@ -1,2 +1,2 @@
-export 'byte_storage_factory_stub.dart'
+export 'byte_storage_factory_web.dart'
     if (dart.library.io) 'byte_storage_factory_io.dart';

--- a/lib/src/cache/byte_storage_factory.dart
+++ b/lib/src/cache/byte_storage_factory.dart
@@ -1,0 +1,2 @@
+export 'byte_storage_factory_stub.dart'
+    if (dart.library.io) 'byte_storage_factory_io.dart';

--- a/lib/src/cache/byte_storage_factory_io.dart
+++ b/lib/src/cache/byte_storage_factory_io.dart
@@ -1,0 +1,14 @@
+import 'dart:io' as io;
+
+import 'package:path_provider/path_provider.dart';
+
+import 'byte_storage.dart';
+import 'byte_storage_io.dart';
+
+Future<io.Directory> cacheStorageResolver() async {
+  final tempFolder = await getTemporaryDirectory();
+  return io.Directory('${tempFolder.path}/.vector_map');
+}
+
+ByteStorage createByteStorage(Future<io.Directory> Function()? cacheFolder) =>
+    IoByteStorage(pather: cacheFolder ?? cacheStorageResolver);

--- a/lib/src/cache/byte_storage_factory_stub.dart
+++ b/lib/src/cache/byte_storage_factory_stub.dart
@@ -1,0 +1,5 @@
+import '../io/io.dart';
+import 'byte_storage.dart';
+
+ByteStorage createByteStorage(Future<Directory> Function()? cacheFolder) =>
+    throw 'Not implemented';

--- a/lib/src/cache/byte_storage_factory_web.dart
+++ b/lib/src/cache/byte_storage_factory_web.dart
@@ -1,0 +1,6 @@
+import '../io/io.dart';
+import 'byte_storage.dart';
+import 'byte_storage_idb.dart';
+
+ByteStorage createByteStorage(Future<Directory> Function()? cacheFolder) =>
+    IdbByteStorage();

--- a/lib/src/cache/byte_storage_idb.dart
+++ b/lib/src/cache/byte_storage_idb.dart
@@ -1,0 +1,95 @@
+import 'dart:typed_data';
+
+import 'package:idb_shim/idb_browser.dart';
+
+import 'byte_storage.dart';
+
+class IdbByteStorage extends ByteStorage {
+  static const _databaseName = 'vector_map_tiles';
+  static const _version = 1;
+  static const _storeName = 'ByteStorage';
+  static const _bytes = 'bytes';
+  static const _size = 'size';
+  static const _modified = 'modified';
+
+  Future<Database> _openDatabase() {
+    final factory = getIdbFactory();
+    if (factory == null) {
+      throw 'Unsupported';
+    }
+    return factory.open(_databaseName,
+        version: _version,
+        onUpgradeNeeded: (e) => e.database.createObjectStore(_storeName));
+  }
+
+  Future<T> _withDb<T>(Future<T> Function(ObjectStore) command,
+      {required _Mode mode}) async {
+    final db = await _openDatabase();
+    try {
+      final tranasaction = db.transaction(
+          _storeName, mode == _Mode.read ? idbModeReadOnly : idbModeReadWrite);
+      final store = tranasaction.objectStore(_storeName);
+      final v = command(store);
+      await tranasaction.completed;
+      return v;
+    } finally {
+      db.close();
+    }
+  }
+
+  @override
+  Future<void> delete(String path) async {
+    await _withDb((s) async => await s.delete(path), mode: _Mode.write);
+  }
+
+  @override
+  Future<bool> exists(String key) =>
+      _withDb((s) async => (await s.getAllKeys()).contains(key),
+          mode: _Mode.read);
+
+  @override
+  Future<List<ByteStorageEntry>> list() async {
+    return await _withDb((s) async {
+      final keys = await s.getAllKeys();
+      final entries = <ByteStorageEntry>[];
+      for (final key in keys) {
+        final object = await s.getObject(key);
+        if (object is Map) {
+          final modified =
+              DateTime.fromMillisecondsSinceEpoch(object[_modified] as int);
+          entries.add(ByteStorageEntry(
+              path: key.toString(),
+              size: object[_size],
+              modified: modified,
+              accessed: modified));
+        }
+      }
+      return entries;
+    }, mode: _Mode.read);
+  }
+
+  @override
+  Future<Uint8List?> read(String path) async {
+    return await _withDb((s) async {
+      final object = await s.getObject(path);
+      if (object is Map) {
+        return object[_bytes] as Uint8List;
+      }
+      return null;
+    }, mode: _Mode.read);
+  }
+
+  @override
+  Future<void> write(String path, Uint8List bytes) async {
+    await _withDb((s) async {
+      await s.put({
+        _bytes: bytes,
+        _modified: DateTime.now().millisecondsSinceEpoch,
+        _size: bytes.length
+      }, path);
+      return null;
+    }, mode: _Mode.write);
+  }
+}
+
+enum _Mode { write, read }

--- a/lib/src/cache/byte_storage_io.dart
+++ b/lib/src/cache/byte_storage_io.dart
@@ -78,7 +78,7 @@ class IoByteStorage extends ByteStorage {
           .asyncMap(_toEntry)
           .where((e) => e.value.type == FileSystemEntityType.file)
           .map((f) => ByteStorageEntry(
-              path: f.key.path,
+              path: f.key.path.split(RegExp(r'/|\\')).last,
               size: f.value.size,
               modified: f.value.modified,
               accessed: f.value.accessed))

--- a/lib/src/cache/byte_storage_io.dart
+++ b/lib/src/cache/byte_storage_io.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'byte_storage.dart';
+
+typedef PathFunction = Future<Directory> Function();
+
+class IoByteStorage extends ByteStorage {
+  final PathFunction _pather;
+  String? _path;
+
+  IoByteStorage._withPath(this._pather);
+
+  IoByteStorage({required PathFunction pather}) : this._withPath(pather);
+
+  Future<String> get _storagePath async {
+    String? path = _path;
+    if (path == null) {
+      final directory = await _pather();
+      final exists = await directory.exists();
+      if (!exists) {
+        await directory.create(recursive: true);
+      }
+      path = directory.path;
+      _path = path;
+    }
+    return path;
+  }
+
+  Future<File> fileOf(String path) async {
+    final root = await _storagePath;
+    return File("$root/$path");
+  }
+
+  Future<Directory> storageDirectory() async {
+    final root = await _storagePath;
+    return Directory(root);
+  }
+
+  @override
+  Future<void> write(String path, Uint8List bytes) async {
+    final file = await fileOf(path);
+    if (!await file.parent.exists()) {
+      await file.parent.create(recursive: true);
+    }
+    await file.writeAsBytes(bytes);
+  }
+
+  @override
+  Future<Uint8List?> read(String path) async {
+    final file = await fileOf(path);
+    if (await file.exists()) {
+      return file.readAsBytes();
+    }
+    return null;
+  }
+
+  @override
+  Future<void> delete(String path) async {
+    final file = await fileOf(path);
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }
+
+  @override
+  Future<bool> exists(String key) async {
+    final file = await fileOf(key);
+    return file.exists();
+  }
+
+  @override
+  Future<List<ByteStorageEntry>> list() async {
+    final directory = await storageDirectory();
+    if (await directory.exists()) {
+      return await directory
+          .list()
+          .asyncMap(_toEntry)
+          .where((e) => e.value.type == FileSystemEntityType.file)
+          .map((f) => ByteStorageEntry(
+              path: f.key.path,
+              size: f.value.size,
+              modified: f.value.modified,
+              accessed: f.value.accessed))
+          .toList();
+    }
+    return [];
+  }
+
+  Future<MapEntry<FileSystemEntity, FileStat>> _toEntry(
+      FileSystemEntity entity) async {
+    return MapEntry(entity, await entity.stat());
+  }
+}

--- a/lib/src/cache/cache_storage_function.dart
+++ b/lib/src/cache/cache_storage_function.dart
@@ -1,8 +1,0 @@
-import 'dart:io';
-
-import 'package:path_provider/path_provider.dart';
-
-Future<Directory> cacheStorageResolver() async {
-  final tempFolder = await getTemporaryDirectory();
-  return Directory('${tempFolder.path}/.vector_map');
-}

--- a/lib/src/cache/caches.dart
+++ b/lib/src/cache/caches.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:executor_lib/executor_lib.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
@@ -34,8 +32,8 @@ class Caches {
       required int memoryTileDataCacheMaxSize,
       required int maxSizeInBytes,
       required int maxTextCacheSize,
-      required Future<Directory> Function() cacheStorage}) {
-    _storage = ByteStorage(pather: cacheStorage);
+      required ByteStorage cacheStorage}) {
+    _storage = cacheStorage;
     final vectorProviders = providers.tileProviderBySource.entries
         .where((e) => e.value.type == TileProviderType.vector);
     providerSources = vectorProviders.map((e) => e.key).toList();

--- a/lib/src/grid/grid_layer.dart
+++ b/lib/src/grid/grid_layer.dart
@@ -7,7 +7,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart' hide TileLayer;
 
-import '../cache/cache_storage_function.dart';
+import '../cache/byte_storage_factory.dart';
 import '../cache/caches.dart';
 import '../options.dart';
 import '../raster/raster_tile_provider.dart';
@@ -204,7 +204,7 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
         memoryTileDataCacheMaxSize: widget.options.memoryTileDataCacheMaxSize,
         maxSizeInBytes: widget.options.fileCacheMaximumSizeInBytes,
         maxTextCacheSize: widget.options.textCacheMaxSize,
-        cacheStorage: widget.options.cacheFolder ?? cacheStorageResolver);
+        cacheStorage: createByteStorage(widget.options.cacheFolder));
     _tileSupplier = TranslatingTileProvider(DelayProvider(
             CachesTileProvider(
                 _caches,

--- a/lib/src/grid/tile_model.dart
+++ b/lib/src/grid/tile_model.dart
@@ -1,5 +1,4 @@
 import 'dart:developer';
-import 'dart:io';
 import 'dart:math';
 import 'dart:ui' as ui;
 
@@ -8,6 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
 import '../../vector_map_tiles.dart';
+import '../io/io.dart';
 import '../profiler.dart';
 import '../stream/tile_supplier.dart';
 import '../stream/tile_supplier_raster.dart';

--- a/lib/src/io/io.dart
+++ b/lib/src/io/io.dart
@@ -1,0 +1,1 @@
+export 'io_stub.dart' if (dart.library.io) 'io_io.dart';

--- a/lib/src/io/io_io.dart
+++ b/lib/src/io/io_io.dart
@@ -1,0 +1,4 @@
+import 'dart:io' as io;
+
+typedef Directory = io.Directory;
+typedef SocketException = io.SocketException;

--- a/lib/src/io/io_stub.dart
+++ b/lib/src/io/io_stub.dart
@@ -1,0 +1,4 @@
+typedef Directory = String;
+typedef SocketException = _SocketException;
+
+class _SocketException {}

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -1,7 +1,6 @@
-import 'dart:io';
-
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
+import 'io/io.dart';
 import 'style/style.dart';
 import 'tile_offset.dart';
 import 'tile_providers.dart';

--- a/lib/src/vector_tile_layer.dart
+++ b/lib/src/vector_tile_layer.dart
@@ -1,11 +1,10 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart' hide Theme;
 import 'package:flutter_map/flutter_map.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
 import 'extensions.dart';
 import 'grid/grid_layer.dart';
+import 'io/io.dart';
 import 'options.dart';
 import 'style/style.dart';
 import 'tile_offset.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_map_tiles
 description: A plugin for `flutter_map` that enables the use of vector tiles.
-version: 8.0.0
+version: 9.0.0-beta.1
 homepage: https://github.com/greensopinion/flutter-vector-map-tiles
 
 environment:
@@ -19,6 +19,7 @@ dependencies:
   async: ^2.8.2
   executor_lib: ^1.1.1
     #path: ../executor_lib
+  idb_shim: ^2.6.1+7
 
 dev_dependencies:
   flutter_lints: ^4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   http: ^1.0.0
   latlong2: ^0.9.0
   path_provider: ^2.0.2
-  vector_tile_renderer: ^5.2.0
-    #path: ../vector_tile_renderer
+  vector_tile_renderer:
+    path: ../dart-vector-tile-renderer
   async: ^2.8.2
   executor_lib: ^1.1.1
     #path: ../executor_lib

--- a/test/src/cache/storage_cache_test.dart
+++ b/test/src/cache/storage_cache_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:test/test.dart';
-import 'package:vector_map_tiles/src/cache/byte_storage.dart';
+import 'package:vector_map_tiles/src/cache/byte_storage_io.dart';
 import 'package:vector_map_tiles/src/cache/storage_cache.dart';
 
 void main() {
@@ -25,7 +25,7 @@ void main() {
   StorageCache newCache(
           {Duration ttl = const Duration(minutes: 1),
           int maxSize = 1024 * 10}) =>
-      StorageCache(ByteStorage(pather: () async => folder!), ttl, maxSize);
+      StorageCache(IoByteStorage(pather: () async => folder!), ttl, maxSize);
 
   test('caches an entry', () async {
     final cache = newCache();


### PR DESCRIPTION
This code update addresses an issue with dispose handling in the AtlasImageCache class. I encountered a problem where, on the main page, which displays a map, go_router redirected the user to another page before the map finished loading. This rapid redirection caused _load to execute after the widget was already disposed, leading to application crashes.

In this updated code:

dispose is carefully checked at each stage of _load to ensure no further operations occur if the widget has been disposed.
Although this approach introduces some repetitive checks, it avoids adding extra complexity and keeps the logic straightforward.
