### PR TITLE
fix omitted layers with multiple sources

### DIFF
--- a/lib/src/raster/tile_loader.dart
+++ b/lib/src/raster/tile_loader.dart
@@ -8,6 +8,7 @@ import 'package:flutter_map/flutter_map.dart' hide TileProvider;
 import 'package:vector_tile_renderer/vector_tile_renderer.dart' hide TileLayer;
 
 import '../../vector_map_tiles.dart';
+import '../extensions.dart';
 import '../grid/slippy_map_translator.dart';
 import '../grid/tile_zoom.dart';
 import '../rendering/tile_renderer.dart';
@@ -18,6 +19,7 @@ import 'storage_image_cache.dart';
 class TileLoader {
   final Theme _theme;
   late final Set<String> _themeSources;
+  late String _sourcesKey;
   final SpriteStyle? _sprites;
   final Future<Image> Function()? _spriteAtlas;
   final TileProvider _provider;
@@ -38,6 +40,7 @@ class TileLoader {
       this._imageCache,
       this._concurrency) {
     _themeSources = _theme.tileSources;
+    _sourcesKey = _theme.tileSources.toList().sorted().join(',');
     _jobQueue = ConcurrencyExecutor(
         delegate: ImmediateExecutor(),
         concurrencyLimit: _concurrency * 2,
@@ -61,7 +64,7 @@ class TileLoader {
         _TileJob(requestedTile, requestZoom, options.tileSize, cancelled);
     return _jobQueue.submit(Job<_TileJob, ImageInfo>(
         'render $requestedTile', _renderJob, job,
-        deduplicationKey: 'render $requestedTile'));
+        deduplicationKey: 'render $requestedTile ${_theme.id}/$_sourcesKey'));
   }
 
   Future<ImageInfo> _renderJob(job) => _renderTile(

--- a/lib/src/stream/tile_processor.dart
+++ b/lib/src/stream/tile_processor.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:executor_lib/executor_lib.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
+import '../extensions.dart';
 import 'tile_supplier.dart';
 
 class TileProcessor {
@@ -13,7 +14,8 @@ class TileProcessor {
 
   Future<Tile> process(TileRequest request, String source, TileData tileData,
       CancellationCallback cancelled) {
-    final key = 'process $source ${request.tileId.key()} clip=${request.clip}';
+    final key =
+        'process $source ${request.tileId.key()} clip=${request.clip} ${request.tileSources.toList().sorted().join(',')}';
     return _executor.submit(Job<_Request, Tile>(
         key, _processTile, _Request(tileData, request.clip),
         cancelled: cancelled, deduplicationKey: key));

--- a/lib/src/stream/tileset_executor_preprocessor.dart
+++ b/lib/src/stream/tileset_executor_preprocessor.dart
@@ -5,6 +5,7 @@ import 'package:executor_lib/executor_lib.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
 import '../../vector_map_tiles.dart';
+import '../extensions.dart';
 
 class TilesetExecutorPreprocessor {
   final TilesetPreprocessor _preprocessor;
@@ -32,7 +33,8 @@ class TilesetExecutorPreprocessor {
     if (!_ready) {
       await _readyCompleter.future;
     }
-    final deduplicationKey = 'preprocess: $identity clip=$clip zoom=$zoom';
+    final deduplicationKey =
+        'preprocess: $identity clip=$clip zoom=$zoom sources=${tileset.tiles.keys.toList().sorted().join(',')}';
     final preprocessed = await _executor.submit(Job(deduplicationKey,
         _preprocessTile, _TilesetAndZoom(_preprocessor.theme.id, tileset, zoom),
         cancelled: cancelled, deduplicationKey: deduplicationKey));

--- a/lib/src/stream/tileset_ui_preprocessor.dart
+++ b/lib/src/stream/tileset_ui_preprocessor.dart
@@ -5,6 +5,7 @@ import 'package:executor_lib/executor_lib.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
 import '../../vector_map_tiles.dart';
+import '../extensions.dart';
 
 class TilesetUiPreprocessor {
   final TilesetPreprocessor _preprocessor;
@@ -14,7 +15,8 @@ class TilesetUiPreprocessor {
 
   Future<Tileset> preprocess(TileIdentity identity, Tileset tileset,
       Rectangle<double>? clip, int zoom, CancellationCallback cancelled) async {
-    final deduplicationKey = 'preprocess ui: $identity clip=$clip zoom=$zoom';
+    final deduplicationKey =
+        'preprocess ui: $identity clip=$clip zoom=$zoom sources=${tileset.tiles.keys.toList().sorted().join(',')}';
     return await _executor.submit(Job(
         deduplicationKey, _preprocessTile, _TilesetAndZoom(tileset, zoom),
         cancelled: cancelled, deduplicationKey: deduplicationKey));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_map_tiles
 description: A plugin for `flutter_map` that enables the use of vector tiles.
-version: 9.0.0-beta.4
+version: 9.0.0-beta.5
 homepage: https://github.com/greensopinion/flutter-vector-map-tiles
 
 environment:


### PR DESCRIPTION
Fix an issue that caused incorrect sources to be
used occasionally when rendering a tile. The issue is intermittent, depending on timing.

The problem was caused by deduplication keys that
did not account for the sources used in a job.
By having incorrect deduplications keys, a job
could complete with the results of a different
job for the same tile. The issue is fixed by
adding sources to the deduplication key.