### PR TITLE
feat: added `StyleReader.constructTileProvider` & made `NetworkVectorTileProvider` a little more extendable

### DIFF
--- a/lib/src/style/style.dart
+++ b/lib/src/style/style.dart
@@ -43,8 +43,8 @@ class StyleReader {
   /// Callback to construct a vector tile provider given parameters read from
   /// the style
   ///
-  /// Defaults to a standard [NetworkVectorTileProvider].
-  final NetworkVectorTileProvider Function(
+  /// Defaults to a standard [VectorTileProvider].
+  final VectorTileProvider Function(
     TileProviderType? type,
     String urlTemplate,
     int minimumZoom,

--- a/lib/src/style/style.dart
+++ b/lib/src/style/style.dart
@@ -44,12 +44,12 @@ class StyleReader {
   /// the style
   ///
   /// Defaults to a standard [NetworkVectorTileProvider].
-  final NetworkVectorTileProvider Function({
+  final NetworkVectorTileProvider Function(
     TileProviderType? type,
     String urlTemplate,
     int minimumZoom,
     int maximumZoom,
-  })? constructTileProvider;
+  )? constructTileProvider;
 
   StyleReader({
     required this.uri,
@@ -141,19 +141,15 @@ class StyleReader {
       if (entryTiles is List && entryTiles.isNotEmpty) {
         final tileUri = entryTiles[0] as String;
         final tileUrl = StyleUriMapper(key: apiKey).mapTiles(tileUri);
-        providers[entry.key] = constructTileProvider?.call(
-              type: type,
-              urlTemplate: tileUrl,
-              minimumZoom: minzoom,
-              maximumZoom: maxzoom,
-            ) ??
-            NetworkVectorTileProvider(
-              type: type,
-              urlTemplate: tileUrl,
-              maximumZoom: maxzoom,
-              minimumZoom: minzoom,
-              httpHeaders: httpHeaders,
-            );
+        providers[entry.key] =
+            constructTileProvider?.call(type, tileUrl, minzoom, maxzoom) ??
+                NetworkVectorTileProvider(
+                  type: type,
+                  urlTemplate: tileUrl,
+                  maximumZoom: maxzoom,
+                  minimumZoom: minzoom,
+                  httpHeaders: httpHeaders,
+                );
       }
     }
     if (providers.isEmpty) {


### PR DESCRIPTION
This hopefully improves extensibility a little bit. I'm trying to add compatibility for FMTC, and so I need to inherit from `NetworkVectorTileProvider`.

I'm not certain why some of the things were done the way they were in the `NetworkVectorTileProvider`, maybe there's a good reason, so let me know if there's an issue now. But I've removed the small class that generates URLs for it, and moved that method into the class itself (since that's the only place it's used). I've also made the `urlTemplate` an actual property instead of just a constructor argument, so that it can be seen externally.

Since I would imagine a lot of users use the `StyleReader`, it's important for me to be able to hook into it. It was previously very very difficult since the NVTP didn't expose its URL template, so I couldn't even make a function to construct my own provider from the properties of the old. Now, it's possible to directly override how the tile provider is generated. If you don't like this part so much, the other change does make this at least workaround-able.

I've tried to keep changes minimal so, whilst it could be considered breaking, I strongly doubt anyone is actually using it in these ways.