### PR TITLE
refactor: migrate TileViewport & Bounds logic to flutter_map v8

### DIFF
--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
 
 PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -28,8 +28,8 @@ dependencies:
     #path: ../../vector_tile_renderer
   vector_map_tiles:
     path: ../
-  flutter_map: ^7.0.2
-  latlong2: ^0.9.0
+  flutter_map: ^8.1.1
+  latlong2: ^0.9.1
 
 dev_dependencies:
   flutter_lints: ^2.0.1

--- a/lib/src/cache/atlas_image_cache.dart
+++ b/lib/src/cache/atlas_image_cache.dart
@@ -3,9 +3,9 @@ import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:executor_lib/executor_lib.dart';
-import 'package:vector_map_tiles/src/raster/images.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
+import '../raster/images.dart';
 import 'extensions.dart';
 import 'storage_cache.dart';
 

--- a/lib/src/cache/image_loading_cache.dart
+++ b/lib/src/cache/image_loading_cache.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 import 'dart:ui';
 
-import 'package:vector_map_tiles/src/raster/images.dart';
+import '../raster/images.dart';
 
 import '../../vector_map_tiles.dart';
 import 'cache.dart';

--- a/lib/src/cache/vector_tile_loading_cache.dart
+++ b/lib/src/cache/vector_tile_loading_cache.dart
@@ -174,7 +174,7 @@ TileData _createTile(_ThemeTile themeTile) {
           .createTileData(VectorTileReader().read(themeTile.bytes));
   final translation = themeTile.translation;
   if (translation != null && tileData.layers.isNotEmpty) {
-    final clipSize = tileSize.x / translation.fraction;
+    final clipSize = tileSize.width / translation.fraction;
     final dx = (translation.xOffset * clipSize);
     final dy = (translation.yOffset * clipSize);
     final clip = Rectangle(dx, dy, clipSize, clipSize);

--- a/lib/src/grid/constants.dart
+++ b/lib/src/grid/constants.dart
@@ -1,4 +1,4 @@
-import 'dart:math';
+import 'dart:ui';
 
 const _tileSize = 256.0;
-const tileSize = Point<double>(_tileSize, _tileSize);
+const tileSize = Size(_tileSize, _tileSize);

--- a/lib/src/grid/grid_layer.dart
+++ b/lib/src/grid/grid_layer.dart
@@ -43,16 +43,13 @@ class VectorTileCompositeLayer extends StatefulWidget {
   }
 }
 
-class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
-    with WidgetsBindingObserver {
+class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer> with WidgetsBindingObserver {
   late Executor _executor;
   late Caches _caches;
   late TileProvider _tileSupplier;
   late RasterTileProvider _rasterTileProvider;
   late final _cacheStats = ScheduledDebounce(_printCacheStats,
-      delay: const Duration(seconds: 1),
-      jitter: const Duration(milliseconds: 0),
-      maxAge: const Duration(seconds: 3));
+      delay: const Duration(seconds: 1), jitter: const Duration(milliseconds: 0), maxAge: const Duration(seconds: 3));
   final _mapChanged = StreamController.broadcast();
   _MapState? _previousState;
   StreamSubscription<void>? _subscription;
@@ -64,15 +61,10 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
       _theme ??
       (_theme = widget.options.layerMode == VectorTileLayerMode.raster
           ? widget.options.theme
-          : widget.options.theme.copyWith(
-              types: ThemeLayerType.values
-                  .where((it) => it != ThemeLayerType.symbol)
-                  .toSet()));
+          : widget.options.theme.copyWith(types: ThemeLayerType.values.where((it) => it != ThemeLayerType.symbol).toSet()));
+
   Theme get symbolTheme =>
-      _symbolTheme ??
-      (_symbolTheme = widget.options.theme.copyWith(
-          id: '${widget.options.theme.id}-symbols',
-          types: {ThemeLayerType.symbol}));
+      _symbolTheme ?? (_symbolTheme = widget.options.theme.copyWith(id: '${widget.options.theme.id}-symbols', types: {ThemeLayerType.symbol}));
 
   @override
   void initState() {
@@ -134,14 +126,7 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
 
       final tileProvider = _tileProvider ??
           createRasterTileProvider(
-              theme,
-              widget.options.sprites,
-              _caches,
-              _rasterTileProvider,
-              _executor,
-              options.tileOffset,
-              options.tileDelay,
-              options.concurrency);
+              theme, widget.options.sprites, _caches, _rasterTileProvider, _executor, options.tileOffset, options.tileDelay, options.concurrency);
       _tileProvider = tileProvider;
       return TileLayer(
           key: Key("${theme.id}_v${theme.version}_VectorTileLayer"),
@@ -153,8 +138,7 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
     final layers = <Widget>[];
     if (backgroundTheme != null) {
       final background = _VectorTileLayer(
-          Key(
-              "${backgroundTheme.id}_v${theme.version}_background_VectorTileLayer"),
+          Key("${backgroundTheme.id}_v${theme.version}_background_VectorTileLayer"),
           _LayerOptions(const TileProviders({}), backgroundTheme,
               caches: _caches,
               showTileDebugInfo: options.showTileDebugInfo,
@@ -168,9 +152,7 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
           widget.mapCamera,
           _mapChanged.stream,
           _tileSupplier,
-          RasterTileProvider(
-              providers: const TileProviders({}),
-              cache: _caches.imageLoadingCache));
+          RasterTileProvider(providers: const TileProviders({}), cache: _caches.imageLoadingCache));
       layers.add(background);
     }
     layers.add(_VectorTileLayer(
@@ -181,8 +163,7 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
             sprites: options.sprites,
             showTileDebugInfo: options.showTileDebugInfo,
             paintBackground: backgroundTheme == null,
-            maxSubstitutionDifference:
-                options.maximumTileSubstitutionDifference,
+            maxSubstitutionDifference: options.maximumTileSubstitutionDifference,
             paintNoDataTiles: false,
             tileOffset: widget.options.tileOffset,
             tileZoomSubstitutionOffset: 0,
@@ -208,18 +189,11 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
         maxTextCacheSize: widget.options.textCacheMaxSize,
         cacheStorage: createByteStorage(widget.options.cacheFolder));
     _tileSupplier = DelayProvider(
-            CachesTileProvider(
-                _caches,
-                TileProcessor(_executor),
-                TilesetExecutorPreprocessor(
-                    TilesetPreprocessor(widget.options.theme), _executor),
-                TilesetUiPreprocessor(TilesetPreprocessor(widget.options.theme,
-                    initializeGeometry: true))),
+            CachesTileProvider(_caches, TileProcessor(_executor), TilesetExecutorPreprocessor(TilesetPreprocessor(widget.options.theme), _executor),
+                TilesetUiPreprocessor(TilesetPreprocessor(widget.options.theme, initializeGeometry: true))),
             widget.options.tileDelay)
         .orDelegate();
-    _rasterTileProvider = RasterTileProvider(
-        providers: widget.options.tileProviders,
-        cache: _caches.imageLoadingCache);
+    _rasterTileProvider = RasterTileProvider(providers: widget.options.tileProviders, cache: _caches.imageLoadingCache);
   }
 
   void _printCacheStats() {
@@ -227,10 +201,7 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
     print('Cache stats:\n${_caches.stats()}');
   }
 
-  double _zoom() => max(
-      1,
-      (widget.mapCamera.zoom + widget.options.tileOffset.zoomOffset)
-          .floorToDouble());
+  double _zoom() => max(1, (widget.mapCamera.zoom + widget.options.tileOffset.zoomOffset).floorToDouble());
 
   double _rotation() => widget.mapCamera.rotationRad;
 }
@@ -249,6 +220,7 @@ class _LayerOptions {
   final double Function() mapZoom;
   final double Function() rotation;
   final Caches caches;
+
   _LayerOptions(this.providers, this.theme,
       {this.symbolTheme,
       this.sprites,
@@ -270,9 +242,7 @@ class _VectorTileLayer extends StatefulWidget {
   final TileProvider tileProvider;
   final RasterTileProvider rasterTileProvider;
 
-  const _VectorTileLayer(Key key, this.options, this.mapState, this.stream,
-      this.tileProvider, this.rasterTileProvider)
-      : super(key: key);
+  const _VectorTileLayer(Key key, this.options, this.mapState, this.stream, this.tileProvider, this.rasterTileProvider) : super(key: key);
 
   @override
   State<StatefulWidget> createState() {
@@ -288,9 +258,11 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
   MapCamera get _mapCamera => widget.mapState;
 
   double get _zoom => widget.options.mapZoom();
-  double get _detailZoom =>
-      widget.options.mapZoom() - widget.options.tileOffset.zoomOffset;
+
+  double get _detailZoom => widget.options.mapZoom() - widget.options.tileOffset.zoomOffset;
+
   double get _clampedZoom => max(1.0, _zoom.floorToDouble());
+
   double get _rotation => widget.options.rotation();
 
   @override
@@ -347,10 +319,7 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
   @override
   Widget build(BuildContext context) {
     _tileWidgets.updateWidgets();
-    final tiles = _tileWidgets.all.entries
-        .where((entry) =>
-            widget.options.paintNoDataTiles || entry.value.model.hasData)
-        .toList(growable: false)
+    final tiles = _tileWidgets.all.entries.where((entry) => widget.options.paintNoDataTiles || entry.value.model.hasData).toList(growable: false)
       ..sort(_orderTileWidgets);
     if (tiles.isEmpty) {
       return Container();
@@ -358,16 +327,10 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
     _zoomScaler.updateMapZoomScale(_mapCamera.zoom);
 
     final tileWidgets = <Widget>[];
-    var positioner = GridTilePositioner(
-        tiles.first.key.z,
-        TilePositioningState(
-            _zoomScaler.zoomScale(tiles.first.key.z), _mapCamera, _zoom));
+    var positioner = GridTilePositioner(tiles.first.key.z, TilePositioningState(_zoomScaler.zoomScale(tiles.first.key.z), _mapCamera, _zoom));
     for (final tile in tiles) {
       if (tile.key.z != positioner.tileZoom) {
-        positioner = GridTilePositioner(
-            tile.key.z,
-            TilePositioningState(
-                _zoomScaler.zoomScale(tile.key.z), _mapCamera, _zoom));
+        positioner = GridTilePositioner(tile.key.z, TilePositioningState(_zoomScaler.zoomScale(tile.key.z), _mapCamera, _zoom));
       }
       tileWidgets.add(positioner.positionTile(tile.key, tile.value));
     }
@@ -390,29 +353,53 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
     _tileWidgets.update(tileViewport, tiles);
   }
 
-  Bounds _tiledPixelBounds() {
+  Rect _tiledPixelBounds() {
     final zoom = _mapCamera.zoom;
     final scale = _mapCamera.getZoomScale(zoom, _clampedZoom);
-    final centerPoint = _mapCamera.project(_mapCamera.center, _clampedZoom);
-    final halfSize = _mapCamera.size / (scale * 2);
+    final center = _mapCamera.projectAtZoom(_mapCamera.center, _clampedZoom); // Offset
+    final halfSize = _mapCamera.size / (scale * 2); // Size
 
-    return Bounds(centerPoint - halfSize, centerPoint + halfSize);
+    final halfSizeOffset = Offset(halfSize.width, halfSize.height);
+    final topLeft = center - halfSizeOffset;
+    final bottomRight = center + halfSizeOffset;
+
+    return Rect.fromLTRB(topLeft.dx, topLeft.dy, bottomRight.dx, bottomRight.dy);
   }
 
-  TileViewport _pixelBoundsToTileViewport(Bounds pixelBounds) {
+  TileViewport _pixelBoundsToTileViewport(Rect pixelBounds) {
     final zoom = _clampedZoom.toInt();
-    final a = pixelBounds.min.unscaleBy(tileSize).floor();
-    final b = pixelBounds.max.unscaleBy(tileSize).ceil() - const Point(1, 1);
-    final topLeft = Point<int>(a.x.toInt(), a.y.toInt());
-    final bottomRight = Point<int>(b.x.toInt(), b.y.toInt());
-    return TileViewport(zoom, Bounds<int>(topLeft, bottomRight));
+    final topLeft = Offset(
+      (pixelBounds.left / tileSize.width).floorToDouble(),
+      (pixelBounds.top / tileSize.height).floorToDouble(),
+    );
+    final bottomRight = Offset(
+      (pixelBounds.right / tileSize.width).ceilToDouble() - 1,
+      (pixelBounds.bottom / tileSize.height).ceilToDouble() - 1,
+    );
+    final tileRect = Rect.fromLTRB(
+      topLeft.dx,
+      topLeft.dy,
+      bottomRight.dx,
+      bottomRight.dy,
+    );
+
+    return TileViewport(
+      zoom,
+      tileRect,
+    );
   }
 
   List<TileIdentity> _expand(TileViewport viewport) {
-    final bounds = viewport.bounds;
+    final rect = viewport.bounds;
     final tiles = <TileIdentity>[];
-    for (int x = bounds.min.x; x <= bounds.max.x; ++x) {
-      for (int y = bounds.min.y; y <= bounds.max.y; ++y) {
+
+    final minX = rect.left.floor();
+    final maxX = rect.right.ceil();
+    final minY = rect.top.floor();
+    final maxY = rect.bottom.ceil();
+
+    for (int x = minX; x <= maxX; ++x) {
+      for (int y = minY; y <= maxY; ++y) {
         if (x >= 0 && y >= 0) {
           final tile = TileIdentity(viewport.zoom, x, y);
           if (tile.isValid()) {
@@ -425,8 +412,7 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
   }
 }
 
-int _orderTileWidgets(
-    MapEntry<TileIdentity, Widget> a, MapEntry<TileIdentity, Widget> b) {
+int _orderTileWidgets(MapEntry<TileIdentity, Widget> a, MapEntry<TileIdentity, Widget> b) {
   int i = a.key.z.compareTo(b.key.z);
   if (i == 0) {
     i = a.key.x.compareTo(b.key.x);
@@ -462,32 +448,30 @@ class _ZoomScaler {
 class _MapState {
   final double zoom;
   final double rotation;
-  final Point pixelOrigin;
+  final Offset pixelOrigin;
   final LatLng center;
-  final Point<double> size;
+  final Size size;
   final LatLngBounds bounds;
-  final Bounds pixelBounds;
+  final Rect pixelBounds;
 
-  _MapState(this.zoom, this.rotation, this.pixelOrigin, this.center, this.size,
-      this.bounds, this.pixelBounds);
+  _MapState(this.zoom, this.rotation, this.pixelOrigin, this.center, this.size, this.bounds, this.pixelBounds);
 
   @override
-  operator ==(other) =>
-      other is _MapState &&
-      zoom == other.zoom &&
-      pixelOrigin == other.pixelOrigin &&
-      center == other.center &&
-      size == other.size &&
-      bounds == other.bounds &&
-      pixelBounds.min == other.pixelBounds.min &&
-      pixelBounds.max == other.pixelBounds.max &&
-      rotation == other.rotation;
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+          other is _MapState &&
+              zoom == other.zoom &&
+              pixelOrigin == other.pixelOrigin &&
+              center == other.center &&
+              size == other.size &&
+              bounds == other.bounds &&
+              pixelBounds == other.pixelBounds &&
+              rotation == other.rotation;
 
   @override
   int get hashCode => Object.hash(zoom, center, size);
 }
 
 extension _MapStateExtension on MapCamera {
-  _MapState toMapState() => _MapState(
-      zoom, rotation, pixelOrigin, center, size, visibleBounds, pixelBounds);
+  _MapState toMapState() => _MapState(zoom, rotation, pixelOrigin, center, size, visibleBounds, pixelBounds);
 }

--- a/lib/src/grid/grid_layer.dart
+++ b/lib/src/grid/grid_layer.dart
@@ -43,13 +43,16 @@ class VectorTileCompositeLayer extends StatefulWidget {
   }
 }
 
-class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer> with WidgetsBindingObserver {
+class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
+    with WidgetsBindingObserver {
   late Executor _executor;
   late Caches _caches;
   late TileProvider _tileSupplier;
   late RasterTileProvider _rasterTileProvider;
   late final _cacheStats = ScheduledDebounce(_printCacheStats,
-      delay: const Duration(seconds: 1), jitter: const Duration(milliseconds: 0), maxAge: const Duration(seconds: 3));
+      delay: const Duration(seconds: 1),
+      jitter: const Duration(milliseconds: 0),
+      maxAge: const Duration(seconds: 3));
   final _mapChanged = StreamController.broadcast();
   _MapState? _previousState;
   StreamSubscription<void>? _subscription;
@@ -61,10 +64,16 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer> wit
       _theme ??
       (_theme = widget.options.layerMode == VectorTileLayerMode.raster
           ? widget.options.theme
-          : widget.options.theme.copyWith(types: ThemeLayerType.values.where((it) => it != ThemeLayerType.symbol).toSet()));
+          : widget.options.theme.copyWith(
+              types: ThemeLayerType.values
+                  .where((it) => it != ThemeLayerType.symbol)
+                  .toSet()));
 
   Theme get symbolTheme =>
-      _symbolTheme ?? (_symbolTheme = widget.options.theme.copyWith(id: '${widget.options.theme.id}-symbols', types: {ThemeLayerType.symbol}));
+      _symbolTheme ??
+      (_symbolTheme = widget.options.theme.copyWith(
+          id: '${widget.options.theme.id}-symbols',
+          types: {ThemeLayerType.symbol}));
 
   @override
   void initState() {
@@ -126,7 +135,14 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer> wit
 
       final tileProvider = _tileProvider ??
           createRasterTileProvider(
-              theme, widget.options.sprites, _caches, _rasterTileProvider, _executor, options.tileOffset, options.tileDelay, options.concurrency);
+              theme,
+              widget.options.sprites,
+              _caches,
+              _rasterTileProvider,
+              _executor,
+              options.tileOffset,
+              options.tileDelay,
+              options.concurrency);
       _tileProvider = tileProvider;
       return TileLayer(
           key: Key("${theme.id}_v${theme.version}_VectorTileLayer"),
@@ -138,7 +154,8 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer> wit
     final layers = <Widget>[];
     if (backgroundTheme != null) {
       final background = _VectorTileLayer(
-          Key("${backgroundTheme.id}_v${theme.version}_background_VectorTileLayer"),
+          Key(
+              "${backgroundTheme.id}_v${theme.version}_background_VectorTileLayer"),
           _LayerOptions(const TileProviders({}), backgroundTheme,
               caches: _caches,
               showTileDebugInfo: options.showTileDebugInfo,
@@ -152,7 +169,9 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer> wit
           widget.mapCamera,
           _mapChanged.stream,
           _tileSupplier,
-          RasterTileProvider(providers: const TileProviders({}), cache: _caches.imageLoadingCache));
+          RasterTileProvider(
+              providers: const TileProviders({}),
+              cache: _caches.imageLoadingCache));
       layers.add(background);
     }
     layers.add(_VectorTileLayer(
@@ -163,7 +182,8 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer> wit
             sprites: options.sprites,
             showTileDebugInfo: options.showTileDebugInfo,
             paintBackground: backgroundTheme == null,
-            maxSubstitutionDifference: options.maximumTileSubstitutionDifference,
+            maxSubstitutionDifference:
+                options.maximumTileSubstitutionDifference,
             paintNoDataTiles: false,
             tileOffset: widget.options.tileOffset,
             tileZoomSubstitutionOffset: 0,
@@ -189,11 +209,18 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer> wit
         maxTextCacheSize: widget.options.textCacheMaxSize,
         cacheStorage: createByteStorage(widget.options.cacheFolder));
     _tileSupplier = DelayProvider(
-            CachesTileProvider(_caches, TileProcessor(_executor), TilesetExecutorPreprocessor(TilesetPreprocessor(widget.options.theme), _executor),
-                TilesetUiPreprocessor(TilesetPreprocessor(widget.options.theme, initializeGeometry: true))),
+            CachesTileProvider(
+                _caches,
+                TileProcessor(_executor),
+                TilesetExecutorPreprocessor(
+                    TilesetPreprocessor(widget.options.theme), _executor),
+                TilesetUiPreprocessor(TilesetPreprocessor(widget.options.theme,
+                    initializeGeometry: true))),
             widget.options.tileDelay)
         .orDelegate();
-    _rasterTileProvider = RasterTileProvider(providers: widget.options.tileProviders, cache: _caches.imageLoadingCache);
+    _rasterTileProvider = RasterTileProvider(
+        providers: widget.options.tileProviders,
+        cache: _caches.imageLoadingCache);
   }
 
   void _printCacheStats() {
@@ -201,7 +228,10 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer> wit
     print('Cache stats:\n${_caches.stats()}');
   }
 
-  double _zoom() => max(1, (widget.mapCamera.zoom + widget.options.tileOffset.zoomOffset).floorToDouble());
+  double _zoom() => max(
+      1,
+      (widget.mapCamera.zoom + widget.options.tileOffset.zoomOffset)
+          .floorToDouble());
 
   double _rotation() => widget.mapCamera.rotationRad;
 }
@@ -242,7 +272,9 @@ class _VectorTileLayer extends StatefulWidget {
   final TileProvider tileProvider;
   final RasterTileProvider rasterTileProvider;
 
-  const _VectorTileLayer(Key key, this.options, this.mapState, this.stream, this.tileProvider, this.rasterTileProvider) : super(key: key);
+  const _VectorTileLayer(Key key, this.options, this.mapState, this.stream,
+      this.tileProvider, this.rasterTileProvider)
+      : super(key: key);
 
   @override
   State<StatefulWidget> createState() {
@@ -259,7 +291,8 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
 
   double get _zoom => widget.options.mapZoom();
 
-  double get _detailZoom => widget.options.mapZoom() - widget.options.tileOffset.zoomOffset;
+  double get _detailZoom =>
+      widget.options.mapZoom() - widget.options.tileOffset.zoomOffset;
 
   double get _clampedZoom => max(1.0, _zoom.floorToDouble());
 
@@ -319,7 +352,10 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
   @override
   Widget build(BuildContext context) {
     _tileWidgets.updateWidgets();
-    final tiles = _tileWidgets.all.entries.where((entry) => widget.options.paintNoDataTiles || entry.value.model.hasData).toList(growable: false)
+    final tiles = _tileWidgets.all.entries
+        .where((entry) =>
+            widget.options.paintNoDataTiles || entry.value.model.hasData)
+        .toList(growable: false)
       ..sort(_orderTileWidgets);
     if (tiles.isEmpty) {
       return Container();
@@ -327,10 +363,16 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
     _zoomScaler.updateMapZoomScale(_mapCamera.zoom);
 
     final tileWidgets = <Widget>[];
-    var positioner = GridTilePositioner(tiles.first.key.z, TilePositioningState(_zoomScaler.zoomScale(tiles.first.key.z), _mapCamera, _zoom));
+    var positioner = GridTilePositioner(
+        tiles.first.key.z,
+        TilePositioningState(
+            _zoomScaler.zoomScale(tiles.first.key.z), _mapCamera, _zoom));
     for (final tile in tiles) {
       if (tile.key.z != positioner.tileZoom) {
-        positioner = GridTilePositioner(tile.key.z, TilePositioningState(_zoomScaler.zoomScale(tile.key.z), _mapCamera, _zoom));
+        positioner = GridTilePositioner(
+            tile.key.z,
+            TilePositioningState(
+                _zoomScaler.zoomScale(tile.key.z), _mapCamera, _zoom));
       }
       tileWidgets.add(positioner.positionTile(tile.key, tile.value));
     }
@@ -356,14 +398,16 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
   Rect _tiledPixelBounds() {
     final zoom = _mapCamera.zoom;
     final scale = _mapCamera.getZoomScale(zoom, _clampedZoom);
-    final center = _mapCamera.projectAtZoom(_mapCamera.center, _clampedZoom); // Offset
+    final center =
+        _mapCamera.projectAtZoom(_mapCamera.center, _clampedZoom); // Offset
     final halfSize = _mapCamera.size / (scale * 2); // Size
 
     final halfSizeOffset = Offset(halfSize.width, halfSize.height);
     final topLeft = center - halfSizeOffset;
     final bottomRight = center + halfSizeOffset;
 
-    return Rect.fromLTRB(topLeft.dx, topLeft.dy, bottomRight.dx, bottomRight.dy);
+    return Rect.fromLTRB(
+        topLeft.dx, topLeft.dy, bottomRight.dx, bottomRight.dy);
   }
 
   TileViewport _pixelBoundsToTileViewport(Rect pixelBounds) {
@@ -412,7 +456,8 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
   }
 }
 
-int _orderTileWidgets(MapEntry<TileIdentity, Widget> a, MapEntry<TileIdentity, Widget> b) {
+int _orderTileWidgets(
+    MapEntry<TileIdentity, Widget> a, MapEntry<TileIdentity, Widget> b) {
   int i = a.key.z.compareTo(b.key.z);
   if (i == 0) {
     i = a.key.x.compareTo(b.key.x);
@@ -454,24 +499,26 @@ class _MapState {
   final LatLngBounds bounds;
   final Rect pixelBounds;
 
-  _MapState(this.zoom, this.rotation, this.pixelOrigin, this.center, this.size, this.bounds, this.pixelBounds);
+  _MapState(this.zoom, this.rotation, this.pixelOrigin, this.center, this.size,
+      this.bounds, this.pixelBounds);
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is _MapState &&
-              zoom == other.zoom &&
-              pixelOrigin == other.pixelOrigin &&
-              center == other.center &&
-              size == other.size &&
-              bounds == other.bounds &&
-              pixelBounds == other.pixelBounds &&
-              rotation == other.rotation;
+      other is _MapState &&
+          zoom == other.zoom &&
+          pixelOrigin == other.pixelOrigin &&
+          center == other.center &&
+          size == other.size &&
+          bounds == other.bounds &&
+          pixelBounds == other.pixelBounds &&
+          rotation == other.rotation;
 
   @override
   int get hashCode => Object.hash(zoom, center, size);
 }
 
 extension _MapStateExtension on MapCamera {
-  _MapState toMapState() => _MapState(zoom, rotation, pixelOrigin, center, size, visibleBounds, pixelBounds);
+  _MapState toMapState() => _MapState(
+      zoom, rotation, pixelOrigin, center, size, visibleBounds, pixelBounds);
 }

--- a/lib/src/grid/grid_tile_positioner.dart
+++ b/lib/src/grid/grid_tile_positioner.dart
@@ -15,13 +15,10 @@ class GridTilePositioner {
 
   Widget positionTile(TileIdentity tile, Widget tileWidget) {
     final offset = _tileOffset(tile);
-    final toRightPosition =
-        _tileOffset(TileIdentity(tile.z, tile.x + 1, tile.y));
-    final toBottomPosition =
-        _tileOffset(TileIdentity(tile.z, tile.x, tile.y + 1));
+    final toRightPosition = _tileOffset(TileIdentity(tile.z, tile.x + 1, tile.y));
+    final toBottomPosition = _tileOffset(TileIdentity(tile.z, tile.x, tile.y + 1));
     const tileOverlap = 0.5;
-    final p = Rect.fromLTRB(offset.dx, offset.dy,
-        toRightPosition.dx + tileOverlap, toBottomPosition.dy + tileOverlap);
+    final p = Rect.fromLTRB(offset.dx, offset.dy, toRightPosition.dx + tileOverlap, toBottomPosition.dy + tileOverlap);
     return Positioned(
         key: Key('PositionedGridTile_${tile.z}_${tile.x}_${tile.y}'),
         top: _roundSize(offset.dy),
@@ -32,11 +29,13 @@ class GridTilePositioner {
   }
 
   Offset _tileOffset(TileIdentity tile) {
-    final tilePosition =
-        ((tile.toDoublePoint().scaleBy(tileSize) - state.origin) *
-                state.zoomScale) +
-            state.translate;
-    return Offset(tilePosition.x.toDouble(), tilePosition.y.toDouble());
+    final tileOffset = Offset(
+      tile.x.toDouble() * tileSize.width,
+      tile.y.toDouble() * tileSize.height,
+    );
+
+    final tilePosition = (tileOffset - state.origin) * state.zoomScale + state.translate;
+    return tilePosition;
   }
 }
 
@@ -58,7 +57,7 @@ class GridTileSizer {
       effectiveScale = effectiveScale * translation.fraction.toDouble();
     }
     if (effectiveScale != 1.0) {
-      final referenceDimension = tileSize.x / translation.fraction;
+      final referenceDimension = tileSize.width / translation.fraction;
       final scaledSize = effectiveScale * referenceDimension;
       final maxDimension = max(size.width, size.height);
       if (scaledSize < maxDimension) {
@@ -78,24 +77,23 @@ class GridTileSizer {
     }
   }
 
-  Rect tileClip(Size size, double scale) => Rect.fromLTWH(
-      (-translationDelta.dx / scale).abs(),
-      (-translationDelta.dy / scale).abs(),
-      size.width / scale,
-      size.height / scale);
+  Rect tileClip(Size size, double scale) =>
+      Rect.fromLTWH((-translationDelta.dx / scale).abs(), (-translationDelta.dy / scale).abs(), size.width / scale, size.height / scale);
 }
 
 class TilePositioningState {
   final double zoomScale;
-  late final Point<double> origin;
-  late final Point<double> translate;
+  late final Offset origin;
+  late final Offset translate;
 
   TilePositioningState(this.zoomScale, MapCamera mapCamera, double zoom) {
-    final pixelOrigin = mapCamera
-        .getNewPixelOrigin(mapCamera.center, mapCamera.zoom)
-        .round()
-        .toDoublePoint();
-    origin = mapCamera.project(mapCamera.unproject(pixelOrigin, zoom), zoom);
+    final pixelOriginPoint = mapCamera.getNewPixelOrigin(mapCamera.center, mapCamera.zoom);
+
+    final pixelOrigin = Offset(
+      pixelOriginPoint.dx.roundToDouble(),
+      pixelOriginPoint.dy.roundToDouble(),
+    );
+    origin = mapCamera.projectAtZoom(mapCamera.unprojectAtZoom(pixelOrigin, zoom), zoom);
     translate = (origin * zoomScale) - pixelOrigin;
   }
 }
@@ -106,6 +104,5 @@ double _roundSize(double dimension) {
 }
 
 extension _DoublePointExtension on Point<double> {
-  Point<double> scaleBy(Point<num> other) =>
-      Point<double>(x * other.x, y * other.y);
+  Point<double> scaleBy(Point<num> other) => Point<double>(x * other.x, y * other.y);
 }

--- a/lib/src/grid/grid_tile_positioner.dart
+++ b/lib/src/grid/grid_tile_positioner.dart
@@ -111,8 +111,3 @@ double _roundSize(double dimension) {
   double factor = 1000;
   return (dimension * factor).roundToDouble() / factor;
 }
-
-extension _DoublePointExtension on Point<double> {
-  Point<double> scaleBy(Point<num> other) =>
-      Point<double>(x * other.x, y * other.y);
-}

--- a/lib/src/grid/grid_tile_positioner.dart
+++ b/lib/src/grid/grid_tile_positioner.dart
@@ -15,10 +15,13 @@ class GridTilePositioner {
 
   Widget positionTile(TileIdentity tile, Widget tileWidget) {
     final offset = _tileOffset(tile);
-    final toRightPosition = _tileOffset(TileIdentity(tile.z, tile.x + 1, tile.y));
-    final toBottomPosition = _tileOffset(TileIdentity(tile.z, tile.x, tile.y + 1));
+    final toRightPosition =
+        _tileOffset(TileIdentity(tile.z, tile.x + 1, tile.y));
+    final toBottomPosition =
+        _tileOffset(TileIdentity(tile.z, tile.x, tile.y + 1));
     const tileOverlap = 0.5;
-    final p = Rect.fromLTRB(offset.dx, offset.dy, toRightPosition.dx + tileOverlap, toBottomPosition.dy + tileOverlap);
+    final p = Rect.fromLTRB(offset.dx, offset.dy,
+        toRightPosition.dx + tileOverlap, toBottomPosition.dy + tileOverlap);
     return Positioned(
         key: Key('PositionedGridTile_${tile.z}_${tile.x}_${tile.y}'),
         top: _roundSize(offset.dy),
@@ -34,7 +37,8 @@ class GridTilePositioner {
       tile.y.toDouble() * tileSize.height,
     );
 
-    final tilePosition = (tileOffset - state.origin) * state.zoomScale + state.translate;
+    final tilePosition =
+        (tileOffset - state.origin) * state.zoomScale + state.translate;
     return tilePosition;
   }
 }
@@ -77,8 +81,11 @@ class GridTileSizer {
     }
   }
 
-  Rect tileClip(Size size, double scale) =>
-      Rect.fromLTWH((-translationDelta.dx / scale).abs(), (-translationDelta.dy / scale).abs(), size.width / scale, size.height / scale);
+  Rect tileClip(Size size, double scale) => Rect.fromLTWH(
+      (-translationDelta.dx / scale).abs(),
+      (-translationDelta.dy / scale).abs(),
+      size.width / scale,
+      size.height / scale);
 }
 
 class TilePositioningState {
@@ -87,13 +94,15 @@ class TilePositioningState {
   late final Offset translate;
 
   TilePositioningState(this.zoomScale, MapCamera mapCamera, double zoom) {
-    final pixelOriginPoint = mapCamera.getNewPixelOrigin(mapCamera.center, mapCamera.zoom);
+    final pixelOriginPoint =
+        mapCamera.getNewPixelOrigin(mapCamera.center, mapCamera.zoom);
 
     final pixelOrigin = Offset(
       pixelOriginPoint.dx.roundToDouble(),
       pixelOriginPoint.dy.roundToDouble(),
     );
-    origin = mapCamera.projectAtZoom(mapCamera.unprojectAtZoom(pixelOrigin, zoom), zoom);
+    origin = mapCamera.projectAtZoom(
+        mapCamera.unprojectAtZoom(pixelOrigin, zoom), zoom);
     translate = (origin * zoomScale) - pixelOrigin;
   }
 }
@@ -104,5 +113,6 @@ double _roundSize(double dimension) {
 }
 
 extension _DoublePointExtension on Point<double> {
-  Point<double> scaleBy(Point<num> other) => Point<double>(x * other.x, y * other.y);
+  Point<double> scaleBy(Point<num> other) =>
+      Point<double>(x * other.x, y * other.y);
 }

--- a/lib/src/raster/storage_image_cache.dart
+++ b/lib/src/raster/storage_image_cache.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 import 'dart:ui';
 
-import 'package:vector_map_tiles/src/raster/images.dart';
+import 'images.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
 
 import '../../vector_map_tiles.dart';

--- a/lib/src/raster/tile_loader.dart
+++ b/lib/src/raster/tile_loader.dart
@@ -60,8 +60,8 @@ class TileLoader {
     if (cached != null) {
       return ImageInfo(image: cached, scale: _scale);
     }
-    final job =
-        _TileJob(requestedTile, requestZoom, options.tileDimension.toDouble(), cancelled);
+    final job = _TileJob(requestedTile, requestZoom,
+        options.tileDimension.toDouble(), cancelled);
     return _jobQueue.submit(Job<_TileJob, ImageInfo>(
         'render $requestedTile', _renderJob, job,
         deduplicationKey: 'render $requestedTile ${_theme.id}/$_sourcesKey'));

--- a/lib/src/raster/tile_loader.dart
+++ b/lib/src/raster/tile_loader.dart
@@ -61,7 +61,7 @@ class TileLoader {
       return ImageInfo(image: cached, scale: _scale);
     }
     final job =
-        _TileJob(requestedTile, requestZoom, options.tileSize, cancelled);
+        _TileJob(requestedTile, requestZoom, options.tileDimension.toDouble(), cancelled);
     return _jobQueue.submit(Job<_TileJob, ImageInfo>(
         'render $requestedTile', _renderJob, job,
         deduplicationKey: 'render $requestedTile ${_theme.id}/$_sourcesKey'));

--- a/lib/src/tile_viewport.dart
+++ b/lib/src/tile_viewport.dart
@@ -1,8 +1,6 @@
 import 'dart:math';
 import 'dart:ui';
 
-import 'package:flutter_map/flutter_map.dart';
-
 import '../vector_map_tiles.dart';
 
 class TileViewport {

--- a/lib/src/tile_viewport.dart
+++ b/lib/src/tile_viewport.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'dart:ui';
 
 import 'package:flutter_map/flutter_map.dart';
 
@@ -6,7 +7,7 @@ import '../vector_map_tiles.dart';
 
 class TileViewport {
   final int zoom;
-  final Bounds<int> bounds;
+  final Rect bounds;
 
   TileViewport(this.zoom, this.bounds);
 
@@ -14,27 +15,45 @@ class TileViewport {
   /// the given tile
   bool overlaps(TileIdentity tile) {
     if (tile.z == zoom) {
-      return bounds.contains(Point(tile.x, tile.y));
+      return bounds.contains(Offset(tile.x.toDouble(), tile.y.toDouble()));
     }
+
     final zoomDifference = zoom - tile.z;
-    final multiplier = pow(2, zoomDifference.abs()).toInt();
+    final multiplier = pow(2, zoomDifference.abs()).toDouble();
+
     if (zoomDifference > 0) {
-      // tile is bigger
-      final boundsTopLeft =
-          (bounds.topLeft.toDoublePoint() * (1 / multiplier)).floor();
-      final boundsBottomRight =
-          (bounds.bottomRight.toDoublePoint() * (1 / multiplier)).ceil();
-      final tilePoint = Point(tile.x, tile.y);
-      return Bounds(boundsTopLeft, boundsBottomRight)
-          .containsPartialBounds(Bounds(tilePoint, tilePoint));
+      final boundsTopLeft = Offset(
+        (bounds.left / multiplier).floorToDouble(),
+        (bounds.top / multiplier).floorToDouble(),
+      );
+      final boundsBottomRight = Offset(
+        (bounds.right / multiplier).ceilToDouble(),
+        (bounds.bottom / multiplier).ceilToDouble(),
+      );
+
+      final tilePoint = Offset(tile.x.toDouble(), tile.y.toDouble());
+      final tileRect = Rect.fromLTWH(tilePoint.dx, tilePoint.dy, 1, 1);
+      final scaledBounds = Rect.fromLTRB(
+        boundsTopLeft.dx,
+        boundsTopLeft.dy,
+        boundsBottomRight.dx,
+        boundsBottomRight.dy,
+      );
+      return scaledBounds.overlaps(tileRect);
     }
-    // tile is smaller
-    final tileZoomTopLeft = bounds.topLeft * multiplier;
-    if (tile.x >= tileZoomTopLeft.x && tile.y >= tileZoomTopLeft.y) {
-      final tileZoomBottomRight =
-          (bounds.bottomRight + const Point(1, 1)) * multiplier;
-      return tile.x < tileZoomBottomRight.x && tile.y < tileZoomBottomRight.y;
-    }
-    return false;
+    final scaledBoundsTopLeft = Offset(
+      bounds.left * multiplier,
+      bounds.top * multiplier,
+    );
+
+    final scaledBoundsBottomRight = Offset(
+      bounds.right * multiplier,
+      bounds.bottom * multiplier,
+    );
+
+    return tile.x >= scaledBoundsTopLeft.dx &&
+        tile.y >= scaledBoundsTopLeft.dy &&
+        tile.x < scaledBoundsBottomRight.dx &&
+        tile.y < scaledBoundsBottomRight.dy;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_map: ^7.0.2
+  flutter_map: ^8.1.1
   http: ^1.0.0
-  latlong2: ^0.9.0
+  latlong2: ^0.9.1
   path_provider: ^2.0.2
   vector_tile_renderer: ^6.0.0
     #path: ../vector_tile_renderer

--- a/test/src/tile_viewport_test.dart
+++ b/test/src/tile_viewport_test.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'dart:ui';
 
 import 'package:flutter_map/flutter_map.dart';
 import 'package:test/test.dart';
@@ -7,8 +8,10 @@ import 'package:vector_map_tiles/src/tile_viewport.dart';
 
 void main() {
   group('overlaps:', () {
-    final viewport =
-        TileViewport(2, Bounds(const Point(1, 1), const Point(2, 2)));
+    final viewport = TileViewport(
+      2,
+      const Rect.fromLTRB(1.0, 1.0, 3.0, 3.0),
+    );
 
     test('when tile is at same zoom', () {
       expect(viewport.overlaps(TileIdentity(2, 0, 0)), false);
@@ -31,8 +34,10 @@ void main() {
     });
 
     test('when tile is larger', () {
-      final viewport =
-          TileViewport(3, Bounds(const Point(3, 2), const Point(4, 4)));
+      final viewport = TileViewport(
+        3,
+        const Rect.fromLTRB(3.0, 2.0, 5.0, 5.0),
+      );
 
       expect(viewport.overlaps(TileIdentity(0, 0, 0)), true);
 
@@ -54,46 +59,41 @@ void main() {
       test('larger tile zoom', () {
         final larger = TileIdentity(11, 325, 703);
         final viewport = TileViewport(
-            12,
-            Bounds<int>(
-              const Point(649, 1404),
-              const Point(651, 1408),
-            ));
+          12,
+          const Rect.fromLTRB(649.0, 1404.0, 652.0, 1409.0),
+        );
         expect(viewport.overlaps(larger), true);
       });
     });
 
     test('when tile is smaller', () {
-      final viewport =
-          TileViewport(2, Bounds(const Point(1, 1), const Point(2, 2)));
+      final viewport = TileViewport(
+        2,
+        const Rect.fromLTRB(1.0, 1.0, 3.0, 3.0),
+      );
       for (int x = 0; x < 2; ++x) {
         for (int y = 0; y < 8; ++y) {
-          expect(viewport.overlaps(TileIdentity(3, x, y)), false,
-              reason: '$x,$y');
+          expect(viewport.overlaps(TileIdentity(3, x, y)), false, reason: '$x,$y');
         }
       }
       for (int x = 6; x < 8; ++x) {
         for (int y = 0; y < 8; ++y) {
-          expect(viewport.overlaps(TileIdentity(3, x, y)), false,
-              reason: '$x,$y');
+          expect(viewport.overlaps(TileIdentity(3, x, y)), false, reason: '$x,$y');
         }
       }
       for (int x = 0; x < 8; ++x) {
         for (int y = 0; y < 2; ++y) {
-          expect(viewport.overlaps(TileIdentity(3, x, y)), false,
-              reason: '$x,$y');
+          expect(viewport.overlaps(TileIdentity(3, x, y)), false, reason: '$x,$y');
         }
       }
       for (int x = 0; x < 8; ++x) {
         for (int y = 6; y < 8; ++y) {
-          expect(viewport.overlaps(TileIdentity(3, x, y)), false,
-              reason: '$x,$y');
+          expect(viewport.overlaps(TileIdentity(3, x, y)), false, reason: '$x,$y');
         }
       }
       for (int x = 2; x < 6; ++x) {
         for (int y = 2; y < 6; ++y) {
-          expect(viewport.overlaps(TileIdentity(3, x, y)), true,
-              reason: '$x,$y');
+          expect(viewport.overlaps(TileIdentity(3, x, y)), true, reason: '$x,$y');
         }
       }
     });

--- a/test/src/tile_viewport_test.dart
+++ b/test/src/tile_viewport_test.dart
@@ -1,7 +1,5 @@
-import 'dart:math';
 import 'dart:ui';
 
-import 'package:flutter_map/flutter_map.dart';
 import 'package:test/test.dart';
 import 'package:vector_map_tiles/src/tile_identity.dart';
 import 'package:vector_map_tiles/src/tile_viewport.dart';

--- a/test/src/tile_viewport_test.dart
+++ b/test/src/tile_viewport_test.dart
@@ -73,27 +73,32 @@ void main() {
       );
       for (int x = 0; x < 2; ++x) {
         for (int y = 0; y < 8; ++y) {
-          expect(viewport.overlaps(TileIdentity(3, x, y)), false, reason: '$x,$y');
+          expect(viewport.overlaps(TileIdentity(3, x, y)), false,
+              reason: '$x,$y');
         }
       }
       for (int x = 6; x < 8; ++x) {
         for (int y = 0; y < 8; ++y) {
-          expect(viewport.overlaps(TileIdentity(3, x, y)), false, reason: '$x,$y');
+          expect(viewport.overlaps(TileIdentity(3, x, y)), false,
+              reason: '$x,$y');
         }
       }
       for (int x = 0; x < 8; ++x) {
         for (int y = 0; y < 2; ++y) {
-          expect(viewport.overlaps(TileIdentity(3, x, y)), false, reason: '$x,$y');
+          expect(viewport.overlaps(TileIdentity(3, x, y)), false,
+              reason: '$x,$y');
         }
       }
       for (int x = 0; x < 8; ++x) {
         for (int y = 6; y < 8; ++y) {
-          expect(viewport.overlaps(TileIdentity(3, x, y)), false, reason: '$x,$y');
+          expect(viewport.overlaps(TileIdentity(3, x, y)), false,
+              reason: '$x,$y');
         }
       }
       for (int x = 2; x < 6; ++x) {
         for (int y = 2; y < 6; ++y) {
-          expect(viewport.overlaps(TileIdentity(3, x, y)), true, reason: '$x,$y');
+          expect(viewport.overlaps(TileIdentity(3, x, y)), true,
+              reason: '$x,$y');
         }
       }
     });


### PR DESCRIPTION
- Replaced all usages of Point<double> with Size, Point with Offset and Bounds with Rect
- Refactored TileViewport.overlaps(TileIdentity):
- Updated helper methods: 
   -> _tileOffset, _pixelBoundsToTileViewport, and TilePositioningState now rely on Offset, Size, and Rect
- Updated unit tests to reflect the new Rect-based system: 
   -> Converted Bounds(Point, Point) to Rect.fromLTRB(...) -> Added +1 to right/bottom values to ensure full tile inclusion