### PR TITLE
Allow vector tiles to wrap around antimeridian

### DIFF
--- a/lib/src/grid/grid_layer.dart
+++ b/lib/src/grid/grid_layer.dart
@@ -299,6 +299,8 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
 
   double get _rotation => widget.options.rotation();
 
+  bool get _allowWrap => widget.mapState.crs.replicatesWorldLongitude;
+
   @override
   void initState() {
     super.initState();
@@ -363,11 +365,14 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
     }
     _zoomScaler.updateMapZoomScale(_mapCamera.zoom);
 
-    final tileWidgets = <Widget>[];
     var positioner = GridTilePositioner(
         tiles.first.key.z,
         TilePositioningState(
             _zoomScaler.zoomScale(tiles.first.key.z), _mapCamera, _zoom));
+
+    final wrappedOutput = <TileIdentity, Widget>{};
+    final regularOutput = <TileIdentity, Widget>{};
+
     for (final tile in tiles) {
       if (tile.key.z != positioner.tileZoom) {
         positioner = GridTilePositioner(
@@ -375,9 +380,24 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
             TilePositioningState(
                 _zoomScaler.zoomScale(tile.key.z), _mapCamera, _zoom));
       }
-      tileWidgets.add(positioner.positionTile(tile.key, tile.value));
+
+      if (!tile.key.isValid()) {
+        wrappedOutput[tile.key.normalize()] =
+            positioner.positionTile(tile.key, tile.value);
+      } else {
+        regularOutput[tile.key.normalize()] =
+            positioner.positionTile(tile.key, tile.value);
+      }
     }
-    return Stack(children: tileWidgets);
+
+    final regularTileIdentities = regularOutput.keys.toSet();
+    final filteredWrapped = Map.fromEntries(wrappedOutput.entries
+        .where((e) => !regularTileIdentities.contains(e.key)));
+
+    return Stack(children: [
+      ...regularOutput.values,
+      ...filteredWrapped.values,
+    ]);
   }
 
   void _update() {
@@ -445,9 +465,9 @@ class _VectorTileLayerState extends DisposableState<_VectorTileLayer> {
 
     for (int x = minX; x <= maxX; ++x) {
       for (int y = minY; y <= maxY; ++y) {
-        if (x >= 0 && y >= 0) {
+        if (_allowWrap || (x >= 0 && y >= 0)) {
           final tile = TileIdentity(viewport.zoom, x, y);
-          if (tile.isValid()) {
+          if (_allowWrap ? tile.isValidWrapped() : tile.isValid()) {
             tiles.add(tile);
           }
         }

--- a/lib/src/grid/grid_tile_positioner.dart
+++ b/lib/src/grid/grid_tile_positioner.dart
@@ -14,7 +14,7 @@ class GridTilePositioner {
   GridTilePositioner(this.tileZoom, this.state);
 
   Widget positionTile(TileIdentity tile, Widget tileWidget) {
-    final offset = _tileOffset(tile);
+    var offset = _tileOffset(tile);
     final toRightPosition =
         _tileOffset(TileIdentity(tile.z, tile.x + 1, tile.y));
     final toBottomPosition =
@@ -22,8 +22,19 @@ class GridTilePositioner {
     const tileOverlap = 0.5;
     final p = Rect.fromLTRB(offset.dx, offset.dy,
         toRightPosition.dx + tileOverlap, toBottomPosition.dy + tileOverlap);
+
+    if (state.allowWrap) {
+      if (offset.dx < -state.worldWidthPixels / 2) {
+        offset = Offset(offset.dx + state.worldWidthPixels, offset.dy);
+      } else if (offset.dx > state.worldWidthPixels / 2) {
+        offset = Offset(offset.dx - state.worldWidthPixels, offset.dy);
+      }
+    }
+
+    final normalizedTile = tile.normalize();
     return Positioned(
-        key: Key('PositionedGridTile_${tile.z}_${tile.x}_${tile.y}'),
+        key: Key(
+            'PositionedGridTile_${normalizedTile.z}_${normalizedTile.x}_${normalizedTile.y}'),
         top: _roundSize(offset.dy),
         left: _roundSize(offset.dx),
         width: _roundSize(p.width),
@@ -92,6 +103,8 @@ class TilePositioningState {
   final double zoomScale;
   late final Offset origin;
   late final Offset translate;
+  late final double worldWidthPixels;
+  late final bool allowWrap;
 
   TilePositioningState(this.zoomScale, MapCamera mapCamera, double zoom) {
     final pixelOriginPoint =
@@ -104,6 +117,8 @@ class TilePositioningState {
     origin = mapCamera.projectAtZoom(
         mapCamera.unprojectAtZoom(pixelOrigin, zoom), zoom);
     translate = (origin * zoomScale) - pixelOrigin;
+    worldWidthPixels = pow(2, zoom).toDouble() * tileSize.width * zoomScale;
+    allowWrap = mapCamera.crs.replicatesWorldLongitude;
   }
 }
 

--- a/lib/src/tile_identity.dart
+++ b/lib/src/tile_identity.dart
@@ -25,6 +25,14 @@ class TileIdentity extends Point<int> {
     return x < max && y < max;
   }
 
+  bool isValidWrapped() {
+    if (z < 0 || y < 0) {
+      return false;
+    }
+    final max = pow(2, z).toInt();
+    return y < max;
+  }
+
   TileIdentity normalize() {
     final maxX = pow(2, z).toInt();
     if (x >= 0 && x < maxX) {

--- a/lib/src/tile_identity.dart
+++ b/lib/src/tile_identity.dart
@@ -7,10 +7,13 @@ class TileIdentity extends Point<int> {
 
   @override
   operator ==(other) =>
-      other is TileIdentity && x == other.x && y == other.y && z == other.z;
+      other is TileIdentity &&
+      normalize().x == other.normalize().x &&
+      y == other.y &&
+      z == other.z;
 
   @override
-  int get hashCode => Object.hash(x, y, z);
+  int get hashCode => Object.hash(normalize().x, y, z);
 
   @override
   String toString() => key();


### PR DESCRIPTION
This change allows vector tiles to paint on both sides of the antimeridian. It does not allow for tile duplication so more than one world cannot be displayed. The ```crs``` setting from ```MapOptions``` in ```flutter_map``` is respected so the previous behaviour can be restored if desired.

Before:
<img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - 2026-04-26 at 13 40 06" src="https://github.com/user-attachments/assets/e6ee48de-5c63-4f49-8864-385411dc042f" />

After:
<img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - 2026-04-26 at 13 39 10" src="https://github.com/user-attachments/assets/d58ceabc-6470-4b88-b9f9-d1a09eecbf8d" />