### PR TITLE
Add option to disable file cache for vector tiles

### DIFF
--- a/lib/src/cache/caches.dart
+++ b/lib/src/cache/caches.dart
@@ -32,7 +32,8 @@ class Caches {
       required int memoryTileDataCacheMaxSize,
       required int maxSizeInBytes,
       required int maxTextCacheSize,
-      required ByteStorage cacheStorage}) {
+      required ByteStorage cacheStorage,
+      required bool disableVectorTileFileCache}) {
     _storage = cacheStorage;
     final vectorProviders = providers.tileProviderBySource.entries.where((e) =>
         e.value.type == TileProviderType.vector ||
@@ -44,7 +45,7 @@ class Caches {
         MemoryTileDataCache(maxSize: memoryTileDataCacheMaxSize);
     final tileProviders = _createTileProviders(theme, vectorProviders);
     vectorTileCache = VectorTileLoadingCache(
-        storageCache,
+        disableVectorTileFileCache ? null : storageCache,
         memoryVectorTileCache,
         memoryTileDataCache,
         tileProviders,

--- a/lib/src/cache/vector_tile_loading_cache.dart
+++ b/lib/src/cache/vector_tile_loading_cache.dart
@@ -20,7 +20,7 @@ class VectorTileLoadingCache {
   late final String _sourcesKey;
   final MemoryTileDataCache _tileDataCache;
   final MemoryCache _memoryCache;
-  final StorageCache _delegate;
+  final StorageCache? _delegate;
   final TileProviders _providers;
   final Map<String, Future<Uint8List?>> _byteFuturesByKey = {};
   final Map<String, Future<Uint8List?>> _cacheByteFuturesByKey = {};
@@ -136,11 +136,11 @@ class VectorTileLoadingCache {
 
   Future<Uint8List?> _loadBytes(VectorTileProvider provider, String key,
       TileIdentity tile, bool cachedOnly) async {
-    var bytes = _memoryCache.get(key) ?? await _delegate.retrieve(key);
+    var bytes = _memoryCache.get(key) ?? await _delegate?.retrieve(key);
     if (bytes == null && !cachedOnly) {
       bytes = await provider.provide(tile);
       _memoryCache.put(key, bytes);
-      await _delegate.put(key, bytes);
+      await _delegate?.put(key, bytes);
     }
     return bytes;
   }

--- a/lib/src/grid/grid_layer.dart
+++ b/lib/src/grid/grid_layer.dart
@@ -208,7 +208,8 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
         memoryTileDataCacheMaxSize: widget.options.memoryTileDataCacheMaxSize,
         maxSizeInBytes: widget.options.fileCacheMaximumSizeInBytes,
         maxTextCacheSize: widget.options.textCacheMaxSize,
-        cacheStorage: createByteStorage(widget.options.cacheFolder));
+        cacheStorage: createByteStorage(widget.options.cacheFolder),
+        disableVectorTileFileCache: widget.options.disableVectorTileFileCache);
     _tileSupplier = DelayProvider(
             CachesTileProvider(
                 _caches,

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -26,6 +26,7 @@ class VectorTileLayerOptions {
   final VectorTileLayerMode layerMode;
   final double? maximumZoom;
   final Future<Directory> Function()? cacheFolder;
+  final bool disableVectorTileFileCache;
 
   VectorTileLayerOptions(vmt.VectorTileLayer layer)
       : tileProviders = layer.tileProviders,
@@ -46,7 +47,8 @@ class VectorTileLayerOptions {
         tileOffset = layer.tileOffset,
         layerMode = layer.layerMode,
         maximumZoom = layer.maximumZoom,
-        cacheFolder = layer.cacheFolder;
+        cacheFolder = layer.cacheFolder,
+        disableVectorTileFileCache = layer.disableVectorTileFileCache;
 
   bool hasRenderDifferences(VectorTileLayerOptions other) =>
       other.theme.id != theme.id ||

--- a/lib/src/vector_tile_layer.dart
+++ b/lib/src/vector_tile_layer.dart
@@ -115,6 +115,11 @@ class VectorTileLayer extends StatelessWidget {
   /// this function.
   final Future<Directory> Function()? cacheFolder;
 
+  /// Indicates whether to disable writing of vector tiles to the disk cache.
+  /// Disabling the cache can save disk space for implementations serving tiles
+  /// from local files. Generated raster tiles are always cached to disk.
+  final bool disableVectorTileFileCache;
+
   VectorTileLayer(
       {super.key,
       required this.tileProviders,
@@ -135,7 +140,8 @@ class VectorTileLayer extends StatelessWidget {
       this.layerMode = VectorTileLayerMode.raster,
       this.maximumZoom,
       this.tileDelay = const Duration(milliseconds: 0),
-      this.cacheFolder}) {
+      this.cacheFolder,
+      this.disableVectorTileFileCache = false}) {
     assert(concurrency >= 0 && concurrency <= 100);
     final providers = theme.tileSources
         .map((source) => tileProviders.tileProviderBySource[source])


### PR DESCRIPTION
This PR adds the option ```disableVectorTileFileCache```  to ```VectorTileLayer```.
The option defaults to ```false``` which keeps the previous behaviour.

When set to ```true```, vector tiles are no longer written to the file cache.
Other caches are not affected and generated raster tiles are still written to the file cache.

This is useful when vector tiles are already served from local storage and caching would just duplicate data.