### PR TITLE
add clearMemoryCaches capability and shared executor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ api_key.dart
 .buildlog/
 .history
 .svn/
+.kiro/
 
 # IntelliJ related
 *.iml

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,8 +24,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  vector_tile_renderer: ^6.0.0
-    #path: ../../vector_tile_renderer_6_0
+  vector_tile_renderer: ^6.1.0
+    #path: ../../vector_tile_renderer
   vector_map_tiles:
     path: ../
   flutter_map: ^8.1.1

--- a/lib/src/cache/cache.dart
+++ b/lib/src/cache/cache.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:math';
 
 import 'cache_stats.dart';
 
@@ -60,7 +61,7 @@ class Cache<K, V> with CacheStats {
   }
 
   void didHaveMemoryPressure() {
-    maxSize = maxSize ~/ 2;
+    maxSize = max(1, maxSize ~/ 2);
     clear();
   }
 

--- a/lib/src/cache/caches.dart
+++ b/lib/src/cache/caches.dart
@@ -68,6 +68,16 @@ class Caches {
 
   void didHaveMemoryPressure() {
     memoryVectorTileCache.didHaveMemoryPressure();
+    memoryTileDataCache.didHaveMemoryPressure();
+    textCache.didHaveMemoryPressure();
+    imageLoadingCache.memoryCache.didHaveMemoryPressure();
+  }
+
+  void clearMemoryCaches() {
+    memoryVectorTileCache.clear();
+    memoryTileDataCache.clear();
+    textCache.clear();
+    imageLoadingCache.memoryCache.clear();
   }
 
   String stats() {

--- a/lib/src/executors/shared_executor.dart
+++ b/lib/src/executors/shared_executor.dart
@@ -1,0 +1,43 @@
+import 'package:executor_lib/executor_lib.dart';
+import 'package:flutter/foundation.dart';
+
+import 'executors.dart';
+
+// Private module-level state
+Executor? _sharedExecutor;
+int _refCount = 0;
+
+/// Acquires a reference to the shared executor.
+/// Creates a new executor via [newConcurrentExecutor] if none exists.
+/// Increments the reference count.
+Executor acquireSharedExecutor({required int concurrency}) {
+  _sharedExecutor ??= newConcurrentExecutor(concurrency: concurrency);
+  _refCount++;
+  return _sharedExecutor!;
+}
+
+/// Releases a reference to the shared executor.
+/// Decrements the reference count.
+/// Disposes the executor when the count reaches zero.
+void releaseSharedExecutor() {
+  assert(_refCount > 0, 'releaseSharedExecutor called with zero ref count');
+  if (_refCount <= 0) return; // no-op in release mode
+  _refCount--;
+  if (_refCount == 0) {
+    _sharedExecutor?.dispose();
+    _sharedExecutor = null;
+  }
+}
+
+@visibleForTesting
+int get sharedExecutorRefCountForTesting => _refCount;
+
+@visibleForTesting
+Executor? get sharedExecutorForTesting => _sharedExecutor;
+
+@visibleForTesting
+void resetSharedExecutorForTesting() {
+  _sharedExecutor?.dispose();
+  _sharedExecutor = null;
+  _refCount = 0;
+}

--- a/lib/src/grid/grid_layer.dart
+++ b/lib/src/grid/grid_layer.dart
@@ -11,7 +11,7 @@ import 'package:vector_tile_renderer/vector_tile_renderer.dart' hide TileLayer;
 import '../cache/byte_storage_factory.dart';
 import '../cache/caches.dart';
 import '../vector_tile_controller.dart';
-import '../executors/executors.dart';
+import '../executors/shared_executor.dart';
 import '../options.dart';
 import '../raster/raster_tile_provider.dart';
 import '../stream/caches_tile_provider.dart';
@@ -80,7 +80,7 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
   @override
   void initState() {
     super.initState();
-    _executor = newConcurrentExecutor(concurrency: widget.options.concurrency);
+    _executor = acquireSharedExecutor(concurrency: widget.options.concurrency);
     _createCaches();
     attachController(widget.options.controller, _caches);
     Future.delayed(const Duration(seconds: 3), () {
@@ -102,7 +102,7 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
     _caches.dispose();
     _tileProvider?.dispose();
     _tileProvider = null;
-    _executor.dispose();
+    releaseSharedExecutor();
   }
 
   @override

--- a/lib/src/grid/grid_layer.dart
+++ b/lib/src/grid/grid_layer.dart
@@ -10,6 +10,7 @@ import 'package:vector_tile_renderer/vector_tile_renderer.dart' hide TileLayer;
 
 import '../cache/byte_storage_factory.dart';
 import '../cache/caches.dart';
+import '../vector_tile_controller.dart';
 import '../executors/executors.dart';
 import '../options.dart';
 import '../raster/raster_tile_provider.dart';
@@ -81,6 +82,7 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
     super.initState();
     _executor = newConcurrentExecutor(concurrency: widget.options.concurrency);
     _createCaches();
+    attachController(widget.options.controller, _caches);
     Future.delayed(const Duration(seconds: 3), () {
       _caches.applyConstraints();
     });
@@ -93,6 +95,7 @@ class _VectorTileCompositeLayerState extends State<VectorTileCompositeLayer>
 
   @override
   void dispose() {
+    detachController(widget.options.controller);
     super.dispose();
     _subscription?.cancel();
     _mapChanged.close();

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -4,10 +4,12 @@ import 'io/io.dart';
 import 'style/style.dart';
 import 'tile_offset.dart';
 import 'tile_providers.dart';
+import 'vector_tile_controller.dart';
 import 'vector_tile_layer.dart' as vmt;
 import 'vector_tile_layer_mode.dart';
 
 class VectorTileLayerOptions {
+  final VectorTileController? controller;
   final TileProviders tileProviders;
   final Theme theme;
   final SpriteStyle? sprites;
@@ -28,7 +30,8 @@ class VectorTileLayerOptions {
   final Future<Directory> Function()? cacheFolder;
 
   VectorTileLayerOptions(vmt.VectorTileLayer layer)
-      : tileProviders = layer.tileProviders,
+      : controller = layer.controller,
+        tileProviders = layer.tileProviders,
         theme = layer.theme,
         sprites = layer.sprites,
         fileCacheTtl = layer.fileCacheTtl,

--- a/lib/src/vector_tile_controller.dart
+++ b/lib/src/vector_tile_controller.dart
@@ -1,0 +1,47 @@
+import 'cache/caches.dart';
+
+/// A controller for programmatic access to [VectorTileLayer] cache operations.
+///
+/// Create an instance and pass it to [VectorTileLayer.controller].
+/// Use [clearMemoryCaches] to clear all in-memory caches on demand.
+abstract class VectorTileController {
+  /// Creates a [VectorTileController].
+  factory VectorTileController() = _VectorTileControllerImpl;
+
+  /// Clears all in-memory caches without adjusting their max sizes.
+  ///
+  /// If the controller is not attached to a widget, this is a no-op.
+  void clearMemoryCaches();
+}
+
+class _VectorTileControllerImpl implements VectorTileController {
+  Caches? _caches;
+
+  @override
+  void clearMemoryCaches() {
+    _caches?.clearMemoryCaches();
+  }
+
+  void attach(Caches caches) {
+    assert(_caches == null, 'VectorTileController is already attached');
+    _caches = caches;
+  }
+
+  void detach() {
+    _caches = null;
+  }
+}
+
+/// Attaches the [controller] to the given [caches].
+///
+/// This is package-internal and not exported from the library barrel file.
+void attachController(VectorTileController? controller, Caches caches) {
+  (controller as _VectorTileControllerImpl?)?.attach(caches);
+}
+
+/// Detaches the [controller] from its caches.
+///
+/// This is package-internal and not exported from the library barrel file.
+void detachController(VectorTileController? controller) {
+  (controller as _VectorTileControllerImpl?)?.detach();
+}

--- a/lib/src/vector_tile_layer.dart
+++ b/lib/src/vector_tile_layer.dart
@@ -9,6 +9,7 @@ import 'options.dart';
 import 'style/style.dart';
 import 'tile_offset.dart';
 import 'tile_providers.dart';
+import 'vector_tile_controller.dart';
 import 'vector_tile_layer_mode.dart';
 import 'vector_tile_provider.dart';
 
@@ -16,6 +17,12 @@ import 'vector_tile_provider.dart';
 /// of a [FlutterMap].
 /// See readme for details.
 class VectorTileLayer extends StatelessWidget {
+  /// An optional controller for programmatic access to cache operations.
+  ///
+  /// Use [VectorTileController.clearMemoryCaches] to clear all in-memory
+  /// caches on demand.
+  final VectorTileController? controller;
+
   /// provides vector tiles, by source ID where the source ID corresponds to
   /// a source in the theme
   final TileProviders tileProviders;
@@ -117,6 +124,7 @@ class VectorTileLayer extends StatelessWidget {
 
   VectorTileLayer(
       {super.key,
+      this.controller,
       required this.tileProviders,
       required this.theme,
       this.sprites,

--- a/lib/vector_map_tiles.dart
+++ b/lib/vector_map_tiles.dart
@@ -8,6 +8,7 @@ export 'src/theme_extensions.dart';
 export 'src/tile_identity.dart';
 export 'src/tile_offset.dart';
 export 'src/tile_providers.dart';
+export 'src/vector_tile_controller.dart' show VectorTileController;
 export 'src/vector_tile_layer.dart';
 export 'src/vector_tile_layer_mode.dart';
 export 'src/vector_tile_provider.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   http: ^1.0.0
   latlong2: ^0.9.1
   path_provider: ^2.0.2
-  vector_tile_renderer: ^6.0.0
-    #path: ../vector_tile_renderer_6_0
+  vector_tile_renderer: ^6.1.0
+    #path: ../vector_tile_renderer
   async: ^2.8.2
   executor_lib: ^1.1.1
     #path: ../executor_lib

--- a/test/src/executors/shared_executor_test.dart
+++ b/test/src/executors/shared_executor_test.dart
@@ -1,0 +1,233 @@
+import 'dart:math';
+
+import 'package:test/test.dart';
+import 'package:vector_map_tiles/src/executors/shared_executor.dart';
+
+void main() {
+  setUp(() {
+    resetSharedExecutorForTesting();
+  });
+
+  tearDown(() {
+    resetSharedExecutorForTesting();
+  });
+
+  group('acquireSharedExecutor', () {
+    test('first call creates an executor and sets ref count to 1', () {
+      final executor = acquireSharedExecutor(concurrency: 4);
+      expect(executor, isNotNull);
+      expect(sharedExecutorRefCountForTesting, equals(1));
+      expect(sharedExecutorForTesting, same(executor));
+    });
+
+    test('subsequent acquires return the same instance and increment ref count',
+        () {
+      final first = acquireSharedExecutor(concurrency: 4);
+      final second = acquireSharedExecutor(concurrency: 4);
+      final third = acquireSharedExecutor(concurrency: 2);
+
+      expect(second, same(first));
+      expect(third, same(first));
+      expect(sharedExecutorRefCountForTesting, equals(3));
+    });
+  });
+
+  group('releaseSharedExecutor', () {
+    test('decrements ref count', () {
+      acquireSharedExecutor(concurrency: 4);
+      acquireSharedExecutor(concurrency: 4);
+      expect(sharedExecutorRefCountForTesting, equals(2));
+
+      releaseSharedExecutor();
+      expect(sharedExecutorRefCountForTesting, equals(1));
+    });
+
+    test('releasing to zero disposes the executor and nulls the reference', () {
+      final executor = acquireSharedExecutor(concurrency: 4);
+      releaseSharedExecutor();
+
+      expect(sharedExecutorRefCountForTesting, equals(0));
+      expect(sharedExecutorForTesting, isNull);
+      expect(executor.disposed, isTrue);
+    });
+
+    test('with zero ref count triggers assertion in debug mode', () {
+      expect(
+        () => releaseSharedExecutor(),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
+  group('re-creation after full disposal', () {
+    test('returns a new, distinct instance', () {
+      final first = acquireSharedExecutor(concurrency: 4);
+      releaseSharedExecutor();
+
+      expect(sharedExecutorForTesting, isNull);
+
+      final second = acquireSharedExecutor(concurrency: 4);
+      expect(second, isNot(same(first)));
+      expect(second.disposed, isFalse);
+      expect(sharedExecutorRefCountForTesting, equals(1));
+    });
+  });
+
+  group('Property-based tests', () {
+    test(
+      'Feature: shared-executor-instance, Property 2: Reference count correctness',
+      () {
+        // Validates: Requirements 2.1, 2.2, 3.3, 6.3
+        final random = Random();
+
+        for (var iteration = 0; iteration < 100; iteration++) {
+          resetSharedExecutorForTesting();
+          var expectedRefCount = 0;
+          final sequenceLength = random.nextInt(50) + 1;
+
+          for (var i = 0; i < sequenceLength; i++) {
+            // Decide whether to acquire or release
+            final canRelease = expectedRefCount > 0;
+            final shouldAcquire = !canRelease || random.nextBool();
+
+            if (shouldAcquire) {
+              acquireSharedExecutor(concurrency: 4);
+              expectedRefCount++;
+            } else {
+              releaseSharedExecutor();
+              expectedRefCount--;
+            }
+
+            expect(
+              sharedExecutorRefCountForTesting,
+              equals(expectedRefCount),
+              reason:
+                  'Iteration $iteration, step $i: ref count mismatch',
+            );
+          }
+        }
+      },
+    );
+
+    test(
+      'Feature: shared-executor-instance, Property 1: Shared identity',
+      () {
+        // Validates: Requirements 1.1, 1.4, 5.3
+        final random = Random();
+
+        for (var iteration = 0; iteration < 100; iteration++) {
+          resetSharedExecutorForTesting();
+          final acquireCount = random.nextInt(50) + 1;
+          final executors = <dynamic>[];
+
+          for (var i = 0; i < acquireCount; i++) {
+            executors.add(acquireSharedExecutor(concurrency: 4));
+          }
+
+          // All returned references should be identical
+          final first = executors.first;
+          for (var i = 1; i < executors.length; i++) {
+            expect(
+              executors[i],
+              same(first),
+              reason:
+                  'Iteration $iteration: acquire $i returned different instance',
+            );
+          }
+        }
+      },
+    );
+
+    test(
+      'Feature: shared-executor-instance, Property 3: Disposal iff zero references',
+      () {
+        // Validates: Requirements 2.3, 2.4, 5.1, 5.2
+        final random = Random();
+
+        for (var iteration = 0; iteration < 100; iteration++) {
+          resetSharedExecutorForTesting();
+          var refCount = 0;
+          final sequenceLength = random.nextInt(50) + 1;
+
+          for (var i = 0; i < sequenceLength; i++) {
+            final canRelease = refCount > 0;
+            final shouldAcquire = !canRelease || random.nextBool();
+
+            if (shouldAcquire) {
+              acquireSharedExecutor(concurrency: 4);
+              refCount++;
+            } else {
+              releaseSharedExecutor();
+              refCount--;
+            }
+
+            if (refCount == 0) {
+              // Executor should be disposed and null
+              expect(
+                sharedExecutorForTesting,
+                isNull,
+                reason:
+                    'Iteration $iteration, step $i: executor should be null at ref count 0',
+              );
+            } else {
+              // Executor should exist and not be disposed
+              expect(
+                sharedExecutorForTesting,
+                isNotNull,
+                reason:
+                    'Iteration $iteration, step $i: executor should exist at ref count $refCount',
+              );
+              expect(
+                sharedExecutorForTesting!.disposed,
+                isFalse,
+                reason:
+                    'Iteration $iteration, step $i: executor should not be disposed at ref count $refCount',
+              );
+            }
+          }
+        }
+      },
+    );
+
+    test(
+      'Feature: shared-executor-instance, Property 4: Re-creation after full disposal',
+      () {
+        // Validates: Requirements 3.1, 3.2
+        final random = Random();
+
+        for (var iteration = 0; iteration < 100; iteration++) {
+          resetSharedExecutorForTesting();
+          final acquireCount = random.nextInt(20) + 1;
+
+          // Acquire N times
+          for (var i = 0; i < acquireCount; i++) {
+            acquireSharedExecutor(concurrency: 4);
+          }
+          final firstExecutor = sharedExecutorForTesting;
+
+          // Release N times to cause disposal
+          for (var i = 0; i < acquireCount; i++) {
+            releaseSharedExecutor();
+          }
+          expect(sharedExecutorForTesting, isNull,
+              reason: 'Iteration $iteration: executor should be null after full release');
+          expect(firstExecutor!.disposed, isTrue,
+              reason: 'Iteration $iteration: first executor should be disposed');
+
+          // Acquire again — should create a new distinct instance
+          final newExecutor = acquireSharedExecutor(concurrency: 4);
+          expect(
+            newExecutor,
+            isNot(same(firstExecutor)),
+            reason:
+                'Iteration $iteration: new executor should be distinct from disposed one',
+          );
+          expect(newExecutor.disposed, isFalse,
+              reason: 'Iteration $iteration: new executor should not be disposed');
+          expect(sharedExecutorRefCountForTesting, equals(1),
+              reason: 'Iteration $iteration: ref count should be 1 after re-creation');
+        }
+      },
+    );
+  });
+}


### PR DESCRIPTION
Add programmatic capability to clear memory
caches. This enables applications to proactively
release memory.

VectorTileLayer already clears caches and
reduces memory cache max size on memory
pressure signal didHaveMemoryPressure()
so calling this API is unnecessary unless
the application wants to release memory
proactively.

Use a shared executor to avoid spawning
many isolates when multiple pages have
maps.